### PR TITLE
Refactored MBPP Benchmark

### DIFF
--- a/benchmarks/MBPP/unverified/task_id_113.rs
+++ b/benchmarks/MBPP/unverified/task_id_113.rs
@@ -4,18 +4,18 @@ fn main() {}
 
 verus! {
 
-spec fn is_digit_spec(c: char) -> bool {
-    (c as u32) >= 48 && (c as u32) <= 57
+spec fn is_digit_spec(c: u8) -> bool {
+    c >= 48 && c <= 57
 }
 
-fn is_digit(c: char) -> (res: bool)
+fn is_digit(c: u8) -> (res: bool)
     ensures
         res == is_digit_spec(c),
 {
-    (c as u32) >= 48 && (c as u32) <= 57
+    c >= 48 && c <= 57
 }
 
-fn is_integer(text: &Vec<char>) -> (result: bool)
+fn is_integer(text: &Vec<u8>) -> (result: bool)
     ensures
         result == (forall|i: int| 0 <= i < text.len() ==> (#[trigger] is_digit_spec(text[i]))),
 {

--- a/benchmarks/MBPP/unverified/task_id_113.rs
+++ b/benchmarks/MBPP/unverified/task_id_113.rs
@@ -15,7 +15,7 @@ fn is_digit(c: u8) -> (res: bool)
     c >= 48 && c <= 57
 }
 
-fn is_integer(text: &Vec<u8>) -> (result: bool)
+fn is_integer(text: &[u8]) -> (result: bool)
     ensures
         result == (forall|i: int| 0 <= i < text.len() ==> (#[trigger] is_digit_spec(text[i]))),
 {

--- a/benchmarks/MBPP/unverified/task_id_18.rs
+++ b/benchmarks/MBPP/unverified/task_id_18.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-fn contains(str: &Vec<char>, key: char) -> (result: bool)
+fn contains(str: &Vec<u8>, key: u8) -> (result: bool)
     ensures
         result <==> (exists|i: int| 0 <= i < str.len() && (str[i] == key)),
 {
@@ -18,7 +18,7 @@ fn contains(str: &Vec<char>, key: char) -> (result: bool)
     false
 }
 
-fn remove_chars(str1: &Vec<char>, str2: &Vec<char>) -> (result: Vec<char>)
+fn remove_chars(str1: &Vec<u8>, str2: &Vec<u8>) -> (result: Vec<u8>)
     ensures
         forall|i: int|
             0 <= i < result.len() ==> (str1@.contains(#[trigger] result[i]) && !str2@.contains(

--- a/benchmarks/MBPP/unverified/task_id_18.rs
+++ b/benchmarks/MBPP/unverified/task_id_18.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-fn contains(str: &Vec<u8>, key: u8) -> (result: bool)
+fn contains(str: &[u8], key: u8) -> (result: bool)
     ensures
         result <==> (exists|i: int| 0 <= i < str.len() && (str[i] == key)),
 {
@@ -18,7 +18,7 @@ fn contains(str: &Vec<u8>, key: u8) -> (result: bool)
     false
 }
 
-fn remove_chars(str1: &Vec<u8>, str2: &Vec<u8>) -> (result: Vec<u8>)
+fn remove_chars(str1: &[u8], str2: &[u8]) -> (result: Vec<u8>)
     ensures
         forall|i: int|
             0 <= i < result.len() ==> (str1@.contains(#[trigger] result[i]) && !str2@.contains(

--- a/benchmarks/MBPP/unverified/task_id_230.rs
+++ b/benchmarks/MBPP/unverified/task_id_230.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-fn replace_blanks_with_chars(str1: &Vec<char>, ch: char) -> (result: Vec<char>)
+fn replace_blanks_with_chars(str1: &Vec<u8>, ch: u8) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|
@@ -14,10 +14,10 @@ fn replace_blanks_with_chars(str1: &Vec<char>, ch: char) -> (result: Vec<char>)
                 str1[i]
             }),
 {
-    let mut out_str: Vec<char> = Vec::with_capacity(str1.len());
+    let mut out_str: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len() {
-        if str1[index] == ' ' {
+        if str1[index] == 32 {
             out_str.push(ch);
         } else {
             out_str.push(str1[index]);

--- a/benchmarks/MBPP/unverified/task_id_230.rs
+++ b/benchmarks/MBPP/unverified/task_id_230.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-fn replace_blanks_with_chars(str1: &Vec<u8>, ch: u8) -> (result: Vec<u8>)
+fn replace_blanks_with_chars(str1: &[u8], ch: u8) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|

--- a/benchmarks/MBPP/unverified/task_id_424.rs
+++ b/benchmarks/MBPP/unverified/task_id_424.rs
@@ -4,14 +4,14 @@ fn main() {}
 
 verus! {
 
-fn extract_rear_chars(s: &Vec<Vec<char>>) -> (result: Vec<char>)
+fn extract_rear_chars(s: &Vec<Vec<u8>>) -> (result: Vec<u8>)
     requires
         forall|i: int| 0 <= i < s.len() ==> #[trigger] s[i].len() > 0,
     ensures
         s.len() == result.len(),
         forall|i: int| 0 <= i < s.len() ==> result[i] == #[trigger] s[i][s[i].len() - 1],
 {
-    let mut rear_chars: Vec<char> = Vec::with_capacity(s.len());
+    let mut rear_chars: Vec<u8> = Vec::with_capacity(s.len());
     let mut index = 0;
     while index < s.len() {
         let seq = &s[index];

--- a/benchmarks/MBPP/unverified/task_id_454.rs
+++ b/benchmarks/MBPP/unverified/task_id_454.rs
@@ -4,13 +4,13 @@ fn main() {}
 
 verus! {
 
-fn contains_z(text: &Vec<char>) -> (result: bool)
+fn contains_z(text: &[u8]) -> (result: bool)
     ensures
-        result == (exists|i: int| 0 <= i < text.len() && (text[i] == 'Z' || text[i] == 'z')),
+        result == (exists|i: int| 0 <= i < text.len() && (text[i] == 90 || text[i] == 122)),
 {
     let mut index = 0;
     while index < text.len() {
-        if text[index] == 'Z' || text[index] == 'z' {
+        if text[index] == 90 || text[index] == 122 {
             return true;
         }
         index += 1;

--- a/benchmarks/MBPP/unverified/task_id_461.rs
+++ b/benchmarks/MBPP/unverified/task_id_461.rs
@@ -4,15 +4,15 @@ fn main() {}
 
 verus! {
 
-spec fn is_lower_case(c: char) -> bool {
-    (c as u32) >= 97 && (c as u32) <= 122
+spec fn is_lower_case(c: u8) -> bool {
+    c >= 97 && c <= 122
 }
 
-spec fn is_upper_case(c: char) -> bool {
-    (c as u32) >= 65 && (c as u32) <= 90
+spec fn is_upper_case(c: u8) -> bool {
+    c >= 65 && c <= 90
 }
 
-spec fn count_uppercase_recursively(seq: Seq<char>) -> int
+spec fn count_uppercase_recursively(seq: Seq<u8>) -> int
     decreases seq.len(),
 {
     if seq.len() == 0 {
@@ -26,7 +26,7 @@ spec fn count_uppercase_recursively(seq: Seq<char>) -> int
     }
 }
 
-fn count_uppercase(text: &Vec<char>) -> (count: u64)
+fn count_uppercase(text: &Vec<u8>) -> (count: u64)
     ensures
         0 <= count <= text.len(),
         count_uppercase_recursively(text@) == count,
@@ -35,7 +35,7 @@ fn count_uppercase(text: &Vec<char>) -> (count: u64)
     let mut count = 0;
 
     while index < text.len() {
-        if ((text[index] as u32) >= 65 && (text[index] as u32) <= 90) {
+        if (text[index] >= 65 && text[index] <= 90) {
             count += 1;
         }
         index += 1;

--- a/benchmarks/MBPP/unverified/task_id_461.rs
+++ b/benchmarks/MBPP/unverified/task_id_461.rs
@@ -26,7 +26,7 @@ spec fn count_uppercase_recursively(seq: Seq<u8>) -> int
     }
 }
 
-fn count_uppercase(text: &Vec<u8>) -> (count: u64)
+fn count_uppercase(text: &[u8]) -> (count: u64)
     ensures
         0 <= count <= text.len(),
         count_uppercase_recursively(text@) == count,

--- a/benchmarks/MBPP/unverified/task_id_474.rs
+++ b/benchmarks/MBPP/unverified/task_id_474.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-fn replace_chars(str1: &Vec<char>, old_char: char, new_char: char) -> (result: Vec<char>)
+fn replace_chars(str1: &[u8], old_char: u8, new_char: u8) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|

--- a/benchmarks/MBPP/unverified/task_id_477.rs
+++ b/benchmarks/MBPP/unverified/task_id_477.rs
@@ -4,15 +4,15 @@ fn main() {}
 
 verus! {
 
-spec fn is_upper_case(c: char) -> bool {
-    c >= 'A' && c <= 'Z'
+spec fn is_upper_case(c: u8) -> bool {
+    c >= 65 && c <= 90
 }
 
-spec fn shift32_spec(c: char) -> char {
-    ((c as u8) + 32) as char
+spec fn shift32_spec(c: u8) -> u8 {
+    (c + 32) as u8
 }
 
-fn to_lowercase(str1: &Vec<char>) -> (result: Vec<char>)
+fn to_lowercase(str1: &[u8]) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|
@@ -22,11 +22,12 @@ fn to_lowercase(str1: &Vec<char>) -> (result: Vec<char>)
                 str1[i]
             }),
 {
-    let mut lower_case: Vec<char> = Vec::with_capacity(str1.len());
+    let mut lower_case: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len() {
-        if (str1[index] >= 'A' && str1[index] <= 'Z') {
-            lower_case.push(((str1[index] as u8) + 32) as char);
+        if (str1[index] >= 65 && str1[index] <= 90) {
+            lower_case.push((str1[index] + 32) as u8);
+
         } else {
             lower_case.push(str1[index]);
         }

--- a/benchmarks/MBPP/unverified/task_id_557.rs
+++ b/benchmarks/MBPP/unverified/task_id_557.rs
@@ -3,23 +3,23 @@ fn main() {}
 
 verus! {
 
-spec fn is_upper_case(c: char) -> bool {
-    c >= 'A' && c <= 'Z'
+spec fn is_upper_case(c: u8) -> bool {
+    c >= 65 && c <= 90
 }
 
-spec fn shift32_spec(c: char) -> char {
-    ((c as u8) + 32) as char
+spec fn shift32_spec(c: u8) -> u8 {
+    (c + 32) as u8
 }
 
-spec fn is_lower_case(c: char) -> bool {
-    c >= 'a' && c <= 'z'
+spec fn is_lower_case(c: u8) -> bool {
+    c >= 97 && c <= 122
 }
 
-spec fn shift_minus_32_spec(c: char) -> char {
-    ((c as u8) - 32) as char
+spec fn shift_minus_32_spec(c: u8) -> u8 {
+    (c - 32) as u8
 }
 
-spec fn to_toggle_case_spec(s: char) -> char {
+spec fn to_toggle_case_spec(s: u8) -> u8 {
     if is_lower_case(s) {
         shift_minus_32_spec(s)
     } else if is_upper_case(s) {
@@ -29,7 +29,7 @@ spec fn to_toggle_case_spec(s: char) -> char {
     }
 }
 
-fn to_toggle_case(str1: &Vec<char>) -> (toggle_case: Vec<char>)
+fn to_toggle_case(str1: &[u8]) -> (toggle_case: Vec<u8>)
     ensures
         str1@.len() == toggle_case@.len(),
         forall|i: int|
@@ -38,10 +38,10 @@ fn to_toggle_case(str1: &Vec<char>) -> (toggle_case: Vec<char>)
     let mut toggle_case = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len() {
-        if (str1[index] >= 'a' && str1[index] <= 'z') {
-            toggle_case.push(((str1[index] as u8) - 32) as char);
-        } else if (str1[index] >= 'A' && str1[index] <= 'Z') {
-            toggle_case.push(((str1[index] as u8) + 32) as char);
+        if (str1[index] >= 97 && str1[index] <= 122) {
+            toggle_case.push((str1[index] - 32) as u8);
+        } else if (str1[index] >= 65 && str1[index] <= 90) {
+            toggle_case.push((str1[index] + 32) as u8);
         } else {
             toggle_case.push(str1[index]);
         }

--- a/benchmarks/MBPP/unverified/task_id_602.rs
+++ b/benchmarks/MBPP/unverified/task_id_602.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-pub open spec fn count_frequency_rcr(seq: Seq<char>, key: char) -> int
+pub open spec fn count_frequency_rcr(seq: Seq<u8>, key: u8) -> int
     decreases seq.len(),
 {
     if seq.len() == 0 {
@@ -18,7 +18,7 @@ pub open spec fn count_frequency_rcr(seq: Seq<char>, key: char) -> int
     }
 }
 
-fn count_frequency(arr: &Vec<char>, key: char) -> (frequency: usize)
+fn count_frequency(arr: &[u8], key: u8) -> (frequency: usize)
     ensures
         count_frequency_rcr(arr@, key) == frequency,
 {
@@ -33,11 +33,11 @@ fn count_frequency(arr: &Vec<char>, key: char) -> (frequency: usize)
     counter
 }
 
-fn first_repeated_char(str1: &Vec<char>) -> (repeated_char: Option<(usize, char)>)
+fn first_repeated_char(str1: &[u8]) -> (repeated_char: Option<(usize, u8)>)
     ensures
         if let Some((idx, rp_char)) = repeated_char {
             &&& str1@.take(idx as int) =~= str1@.take(idx as int).filter(
-                |x: char| count_frequency_rcr(str1@, x) <= 1,
+                |x: u8| count_frequency_rcr(str1@, x) <= 1,
             )
             &&& count_frequency_rcr(str1@, rp_char) > 1
         } else {

--- a/benchmarks/MBPP/unverified/task_id_624.rs
+++ b/benchmarks/MBPP/unverified/task_id_624.rs
@@ -4,15 +4,15 @@ fn main() {}
 
 verus! {
 
-spec fn is_lower_case(c: char) -> bool {
-    c >= 'a' && c <= 'z'
+spec fn is_lower_case(c: u8) -> bool {
+    c >= 97 && c <= 122
 }
 
-spec fn shift_minus_32_spec(c: char) -> char {
-    ((c as u8) - 32) as char
+spec fn shift_minus_32_spec(c: u8) -> u8 {
+    (c - 32) as u8
 }
 
-fn to_uppercase(str1: &Vec<char>) -> (result: Vec<char>)
+fn to_uppercase(str1: &[u8]) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|
@@ -22,11 +22,11 @@ fn to_uppercase(str1: &Vec<char>) -> (result: Vec<char>)
                 str1[i]
             })),
 {
-    let mut upper_case: Vec<char> = Vec::with_capacity(str1.len());
+    let mut upper_case: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len() {
-        if (str1[index] >= 'a' && str1[index] <= 'z') {
-            upper_case.push(((str1[index] as u8) - 32) as char);
+        if (str1[index] >= 97 && str1[index] <= 122) {
+            upper_case.push((str1[index] - 32) as u8);
         } else {
             upper_case.push(str1[index]);
         }

--- a/benchmarks/MBPP/unverified/task_id_732.rs
+++ b/benchmarks/MBPP/unverified/task_id_732.rs
@@ -4,25 +4,25 @@ fn main() {}
 
 verus! {
 
-spec fn is_space_comma_dot_spec(c: char) -> bool {
-    (c == ' ') || (c == ',') || (c == '.')
+spec fn is_space_comma_dot_spec(c: u8) -> bool {
+    (c == 32) || (c == 44) || (c == 46)
 }
 
-fn replace_with_colon(str1: &Vec<char>) -> (result: Vec<char>)
+fn replace_with_colon(str1: &[u8]) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|k: int|
             0 <= k < result.len() ==> #[trigger] result[k] == (if is_space_comma_dot_spec(str1[k]) {
-                ':'
+                58
             } else {
                 str1[k]
             }),
 {
-    let mut result: Vec<char> = Vec::with_capacity(str1.len());
+    let mut result: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len() {
-        if ((str1[index] == ' ') || (str1[index] == ',') || (str1[index] == '.')) {
-            result.push(':');
+        if ((str1[index] == 32) || (str1[index] == 44) || (str1[index] == 46)) {
+            result.push(58);
         } else {
             result.push(str1[index]);
         }

--- a/benchmarks/MBPP/unverified/task_id_741.rs
+++ b/benchmarks/MBPP/unverified/task_id_741.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 verus! {
 
-fn all_characters_same(char_arr: &Vec<char>) -> (result: bool)
+fn all_characters_same(char_arr: &[u8]) -> (result: bool)
     ensures
         result == (forall|i: int|
             1 <= i < char_arr@.len() ==> char_arr[0] == #[trigger] char_arr[i]),

--- a/benchmarks/MBPP/unverified/task_id_764.rs
+++ b/benchmarks/MBPP/unverified/task_id_764.rs
@@ -4,11 +4,11 @@ fn main() {}
 
 verus! {
 
-spec fn is_digit(c: char) -> bool {
-    (c as u8) >= 48 && (c as u8) <= 57
+spec fn is_digit(c: u8) -> bool {
+    (c >= 48 && c <= 57)
 }
 
-spec fn count_digits_recursively(seq: Seq<char>) -> int
+spec fn count_digits_recursively(seq: Seq<u8>) -> int
     decreases seq.len(),
 {
     if seq.len() == 0 {
@@ -22,15 +22,16 @@ spec fn count_digits_recursively(seq: Seq<char>) -> int
     }
 }
 
-fn count_digits(text: &Vec<char>) -> (count: usize)
+fn count_digits(text: &[u8]) -> (count: usize)
     ensures
         0 <= count <= text.len(),
         count_digits_recursively(text@) == count,
 {
     let mut count = 0;
     let mut index = 0;
+
     while index < text.len() {
-        if ((text[index] as u8) >= 48 && (text[index] as u8) <= 57) {
+        if (text[index] >= 48 && text[index] <= 57) {
             count += 1;
         }
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_113.rs
+++ b/benchmarks/MBPP/verified/task_id_113.rs
@@ -3,25 +3,25 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to check if a string represents an integer or not.
 
-    assert!(!is_integer(&("python".chars().collect())));
-    assert!(is_integer(&("1".chars().collect())));
-    assert!(is_integer(&("123".chars().collect())));
+    assert!(!is_integer(&("python".as_bytes().to_vec())));
+    assert!(is_integer(&("1".as_bytes().to_vec())));
+    assert!(is_integer(&("123".as_bytes().to_vec())));
 }
 
 verus! {
 
-spec fn is_digit_sepc(c: char) -> bool {
-    (c as u32) >= 48 && (c as u32) <= 57
+spec fn is_digit_sepc(c: u8) -> bool {
+    c >= 48 && c <= 57
 }
 
-fn is_digit(c: char) -> (res: bool)
+fn is_digit(c: u8) -> (res: bool)
     ensures
         res == is_digit_sepc(c),
 {
-    (c as u32) >= 48 && (c as u32) <= 57
+    c >= 48 && c <= 57
 }
 
-fn is_integer(text: &Vec<char>) -> (result: bool)
+fn is_integer(text: &Vec<u8>) -> (result: bool)
     ensures
         result == (forall|i: int| 0 <= i < text.len() ==> (#[trigger] is_digit_sepc(text[i]))),
 {

--- a/benchmarks/MBPP/verified/task_id_113.rs
+++ b/benchmarks/MBPP/verified/task_id_113.rs
@@ -3,9 +3,9 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to check if a string represents an integer or not.
 
-    assert!(!is_integer(&("python".as_bytes().to_vec())));
-    assert!(is_integer(&("1".as_bytes().to_vec())));
-    assert!(is_integer(&("123".as_bytes().to_vec())));
+    assert!(!is_integer(b"python"));
+    assert!(is_integer(b"1"));
+    assert!(is_integer(b"123"));
 }
 
 verus! {
@@ -21,7 +21,7 @@ fn is_digit(c: u8) -> (res: bool)
     c >= 48 && c <= 57
 }
 
-fn is_integer(text: &Vec<u8>) -> (result: bool)
+fn is_integer(text: &[u8]) -> (result: bool)
     ensures
         result == (forall|i: int| 0 <= i < text.len() ==> (#[trigger] is_digit_sepc(text[i]))),
 {

--- a/benchmarks/MBPP/verified/task_id_18.rs
+++ b/benchmarks/MBPP/verified/task_id_18.rs
@@ -5,30 +5,24 @@ fn main() {
 
     assert_eq!(
         remove_chars(
-            &("probasscurve".chars().collect()),
-            &("pros".chars().collect())
-        )
-        .iter()
-        .collect::<String>(),
-        "bacuve"
+            &("probasscurve".as_bytes().to_vec()),
+            &("pros".as_bytes().to_vec())
+        ),
+        "bacuve".as_bytes().to_vec()
     );
     assert_eq!(
         remove_chars(
-            &("digitalindia".chars().collect()),
-            &("talent".chars().collect())
-        )
-        .iter()
-        .collect::<String>(),
-        "digiidi"
+            &("digitalindia".as_bytes().to_vec()),
+            &("talent".as_bytes().to_vec())
+        ),
+        "digiidi".as_bytes().to_vec()
     );
     assert_eq!(
         remove_chars(
-            &("exoticmiles".chars().collect()),
-            &("toxic".chars().collect())
-        )
-        .iter()
-        .collect::<String>(),
-        "emles"
+            &("exoticmiles".as_bytes().to_vec()),
+            &("toxic".as_bytes().to_vec())
+        ),
+        "emles".as_bytes().to_vec()
     );
 }
 
@@ -43,7 +37,7 @@ proof fn lemma_vec_push<T>(vec: Seq<T>, i: T, l: usize)
 {
 }
 
-fn contains(str: &Vec<char>, key: char) -> (result: bool)
+fn contains(str: &Vec<u8>, key: u8) -> (result: bool)
     ensures
         result <==> (exists|i: int| 0 <= i < str.len() && (str[i] == key)),
 {
@@ -60,7 +54,7 @@ fn contains(str: &Vec<char>, key: char) -> (result: bool)
     false
 }
 
-fn remove_chars(str1: &Vec<char>, str2: &Vec<char>) -> (result: Vec<char>)
+fn remove_chars(str1: &Vec<u8>, str2: &Vec<u8>) -> (result: Vec<u8>)
     ensures
         forall|i: int|
             0 <= i < result.len() ==> (str1@.contains(#[trigger] result[i]) && !str2@.contains(

--- a/benchmarks/MBPP/verified/task_id_18.rs
+++ b/benchmarks/MBPP/verified/task_id_18.rs
@@ -3,27 +3,9 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to remove characters from the first string which are present in the second string.
 
-    assert_eq!(
-        remove_chars(
-            &("probasscurve".as_bytes().to_vec()),
-            &("pros".as_bytes().to_vec())
-        ),
-        "bacuve".as_bytes().to_vec()
-    );
-    assert_eq!(
-        remove_chars(
-            &("digitalindia".as_bytes().to_vec()),
-            &("talent".as_bytes().to_vec())
-        ),
-        "digiidi".as_bytes().to_vec()
-    );
-    assert_eq!(
-        remove_chars(
-            &("exoticmiles".as_bytes().to_vec()),
-            &("toxic".as_bytes().to_vec())
-        ),
-        "emles".as_bytes().to_vec()
-    );
+    assert_eq!(remove_chars((b"probasscurve"), (b"pros")), b"bacuve");
+    assert_eq!(remove_chars((b"digitalindia"), (b"talent")), b"digiidi");
+    assert_eq!(remove_chars((b"exoticmiles"), (b"toxic")), b"emles");
 }
 
 verus! {
@@ -37,7 +19,7 @@ proof fn lemma_vec_push<T>(vec: Seq<T>, i: T, l: usize)
 {
 }
 
-fn contains(str: &Vec<u8>, key: u8) -> (result: bool)
+fn contains(str: &[u8], key: u8) -> (result: bool)
     ensures
         result <==> (exists|i: int| 0 <= i < str.len() && (str[i] == key)),
 {
@@ -54,7 +36,7 @@ fn contains(str: &Vec<u8>, key: u8) -> (result: bool)
     false
 }
 
-fn remove_chars(str1: &Vec<u8>, str2: &Vec<u8>) -> (result: Vec<u8>)
+fn remove_chars(str1: &[u8], str2: &[u8]) -> (result: Vec<u8>)
     ensures
         forall|i: int|
             0 <= i < result.len() ==> (str1@.contains(#[trigger] result[i]) && !str2@.contains(

--- a/benchmarks/MBPP/verified/task_id_230.rs
+++ b/benchmarks/MBPP/verified/task_id_230.rs
@@ -4,22 +4,22 @@ fn main() {
     // Write a function in Rust that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.
 
     assert_eq!(
-        replace_blanks_with_chars(&("hello people".as_bytes().to_vec()), b'@'),
-        "hello@people".as_bytes().to_vec()
+        replace_blanks_with_chars(b"hello people", b'@'),
+        b"hello@people"
     );
     assert_eq!(
-        replace_blanks_with_chars(&("python program language".as_bytes().to_vec()), b'$'),
-        "python$program$language".as_bytes().to_vec()
+        replace_blanks_with_chars(b"python program language", b'$'),
+        b"python$program$language"
     );
     assert_eq!(
-        replace_blanks_with_chars(&("blank space".as_bytes().to_vec()), b'-'),
-        "blank-space".as_bytes().to_vec()
+        replace_blanks_with_chars(b"blank space", b'-'),
+        b"blank-space"
     );
 }
 
 verus! {
 
-fn replace_blanks_with_chars(str1: &Vec<u8>, ch: u8) -> (result: Vec<u8>)
+fn replace_blanks_with_chars(str1: &[u8], ch: u8) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|

--- a/benchmarks/MBPP/verified/task_id_230.rs
+++ b/benchmarks/MBPP/verified/task_id_230.rs
@@ -4,28 +4,22 @@ fn main() {
     // Write a function in Rust that takes in a string and character, replaces blank spaces in the string with the character, and returns the string.
 
     assert_eq!(
-        replace_blanks_with_chars(&("hello people".chars().collect()), '@')
-            .iter()
-            .collect::<String>(),
-        "hello@people"
+        replace_blanks_with_chars(&("hello people".as_bytes().to_vec()), b'@'),
+        "hello@people".as_bytes().to_vec()
     );
     assert_eq!(
-        replace_blanks_with_chars(&("python program language".chars().collect()), '$')
-            .iter()
-            .collect::<String>(),
-        "python$program$language"
+        replace_blanks_with_chars(&("python program language".as_bytes().to_vec()), b'$'),
+        "python$program$language".as_bytes().to_vec()
     );
     assert_eq!(
-        replace_blanks_with_chars(&("blank space".chars().collect()), '-')
-            .iter()
-            .collect::<String>(),
-        "blank-space"
+        replace_blanks_with_chars(&("blank space".as_bytes().to_vec()), b'-'),
+        "blank-space".as_bytes().to_vec()
     );
 }
 
 verus! {
 
-fn replace_blanks_with_chars(str1: &Vec<char>, ch: char) -> (result: Vec<char>)
+fn replace_blanks_with_chars(str1: &Vec<u8>, ch: u8) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|
@@ -35,20 +29,20 @@ fn replace_blanks_with_chars(str1: &Vec<char>, ch: char) -> (result: Vec<char>)
                 str1[i]
             }),
 {
-    let mut out_str: Vec<char> = Vec::with_capacity(str1.len());
+    let mut out_str: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len()
         invariant
             0 <= index <= str1.len(),
             out_str@.len() == index,
             forall|k: int|
-                0 <= k < index ==> out_str[k] == (if str1[k] == ' ' {
+                0 <= k < index ==> out_str[k] == (if str1[k] == 32 {  // 32 is ASCII Space as u8
                     ch
                 } else {
                     str1[k]
                 }),
     {
-        if (str1[index] == ' ') {
+        if (str1[index] == 32) {  // 32 is ASCII Space as u8
             out_str.push(ch);
         } else {
             out_str.push(str1[index]);

--- a/benchmarks/MBPP/verified/task_id_424.rs
+++ b/benchmarks/MBPP/verified/task_id_424.rs
@@ -5,46 +5,40 @@ fn main() {
 
     assert_eq!(
         extract_rear_chars(&vec![
-            "Mers".chars().collect(),
-            "for".chars().collect(),
-            "Vers".chars().collect()
-        ])
-        .iter()
-        .collect::<String>(),
-        "srs"
+            "Mers".as_bytes().to_vec(),
+            "for".as_bytes().to_vec(),
+            "Vers".as_bytes().to_vec()
+        ]),
+        "srs".as_bytes().to_vec()
     );
     assert_eq!(
         extract_rear_chars(&vec![
-            "Avenge".chars().collect(),
-            "for".chars().collect(),
-            "People".chars().collect()
-        ])
-        .iter()
-        .collect::<String>(),
-        "ere"
+            "Avenge".as_bytes().to_vec(),
+            "for".as_bytes().to_vec(),
+            "People".as_bytes().to_vec()
+        ]),
+        "ere".as_bytes().to_vec()
     );
     assert_eq!(
         extract_rear_chars(&vec![
-            "Gotta".chars().collect(),
-            "get".chars().collect(),
-            "go".chars().collect()
-        ])
-        .iter()
-        .collect::<String>(),
-        "ato"
+            "Gotta".as_bytes().to_vec(),
+            "get".as_bytes().to_vec(),
+            "go".as_bytes().to_vec()
+        ]),
+        "ato".as_bytes().to_vec()
     );
 }
 
 verus! {
 
-fn extract_rear_chars(s: &Vec<Vec<char>>) -> (result: Vec<char>)
+fn extract_rear_chars(s: &Vec<Vec<u8>>) -> (result: Vec<u8>)
     requires
         forall|i: int| 0 <= i < s.len() ==> #[trigger] s[i].len() > 0,
     ensures
         s.len() == result.len(),
         forall|i: int| 0 <= i < s.len() ==> result[i] == #[trigger] s[i][s[i].len() - 1],
 {
-    let mut rear_chars: Vec<char> = Vec::with_capacity(s.len());
+    let mut rear_chars: Vec<u8> = Vec::with_capacity(s.len());
     let mut index = 0;
     while index < s.len()
         invariant

--- a/benchmarks/MBPP/verified/task_id_454.rs
+++ b/benchmarks/MBPP/verified/task_id_454.rs
@@ -3,24 +3,24 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust that matches a word containing 'z'.
 
-    assert!(contains_z(&("pythonz.".chars().collect())));
-    assert!(contains_z(&("xyz.".chars().collect())));
-    assert!(!contains_z(&("  lang  .".chars().collect())));
+    assert!(contains_z(b"pythonz."));
+    assert!(contains_z(b"xyz."));
+    assert!(!contains_z(b"  lang  ."));
 }
 
 verus! {
 
-fn contains_z(text: &Vec<char>) -> (result: bool)
+fn contains_z(text: &[u8]) -> (result: bool)
     ensures
-        result == (exists|i: int| 0 <= i < text.len() && (text[i] == 'Z' || text[i] == 'z')),
+        result == (exists|i: int| 0 <= i < text.len() && (text[i] == 90 || text[i] == 122)),
 {
     let mut index = 0;
     while index < text.len()
         invariant
             0 <= index <= text.len(),
-            forall|k: int| 0 <= k < index ==> (text[k] != 'Z' && text[k] != 'z'),
+            forall|k: int| 0 <= k < index ==> (text[k] != 90 && text[k] != 122),
     {
-        if text[index] == 'Z' || text[index] == 'z' {
+        if text[index] == 90 || text[index] == 122 {
             return true;
         }
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_461.rs
+++ b/benchmarks/MBPP/verified/task_id_461.rs
@@ -3,9 +3,9 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to count the upper case characters in a given string.
 
-    assert_eq!(count_uppercase(&("PYthon".as_bytes().to_vec())), 2);
-    assert_eq!(count_uppercase(&("BigData".as_bytes().to_vec())), 2);
-    assert_eq!(count_uppercase(&("program".as_bytes().to_vec())), 0);
+    assert_eq!(count_uppercase(b"PYthon"), 2);
+    assert_eq!(count_uppercase(b"BigData"), 2);
+    assert_eq!(count_uppercase(b"program"), 0);
 }
 
 verus! {
@@ -32,7 +32,7 @@ spec fn count_uppercase_recursively(seq: Seq<u8>) -> int
     }
 }
 
-fn count_uppercase(text: &Vec<u8>) -> (count: u64)
+fn count_uppercase(text: &[u8]) -> (count: u64)
     ensures
         0 <= count <= text.len(),
         count_uppercase_recursively(text@) == count,

--- a/benchmarks/MBPP/verified/task_id_461.rs
+++ b/benchmarks/MBPP/verified/task_id_461.rs
@@ -3,22 +3,22 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to count the upper case characters in a given string.
 
-    assert_eq!(count_uppercase(&("PYthon".chars().collect())), 2);
-    assert_eq!(count_uppercase(&("BigData".chars().collect())), 2);
-    assert_eq!(count_uppercase(&("program".chars().collect())), 0);
+    assert_eq!(count_uppercase(&("PYthon".as_bytes().to_vec())), 2);
+    assert_eq!(count_uppercase(&("BigData".as_bytes().to_vec())), 2);
+    assert_eq!(count_uppercase(&("program".as_bytes().to_vec())), 0);
 }
 
 verus! {
 
-spec fn is_lower_case(c: char) -> bool {
-    (c as u32) >= 97 && (c as u32) <= 122
+spec fn is_lower_case(c: u8) -> bool {
+    c >= 97 && c <= 122
 }
 
-spec fn is_upper_case(c: char) -> bool {
-    (c as u32) >= 65 && (c as u32) <= 90
+spec fn is_upper_case(c: u8) -> bool {
+    c >= 65 && c <= 90
 }
 
-spec fn count_uppercase_recursively(seq: Seq<char>) -> int
+spec fn count_uppercase_recursively(seq: Seq<u8>) -> int
     decreases seq.len(),
 {
     if seq.len() == 0 {
@@ -32,7 +32,7 @@ spec fn count_uppercase_recursively(seq: Seq<char>) -> int
     }
 }
 
-fn count_uppercase(text: &Vec<char>) -> (count: u64)
+fn count_uppercase(text: &Vec<u8>) -> (count: u64)
     ensures
         0 <= count <= text.len(),
         count_uppercase_recursively(text@) == count,
@@ -46,7 +46,7 @@ fn count_uppercase(text: &Vec<char>) -> (count: u64)
             0 <= count <= index,
             count_uppercase_recursively(text@.subrange(0, index as int)) == count,
     {
-        if ((text[index] as u32) >= 65 && (text[index] as u32) <= 90) {
+        if (text[index] >= 65 && text[index] <= 90) {
             count += 1;
         }
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_474.rs
+++ b/benchmarks/MBPP/verified/task_id_474.rs
@@ -3,18 +3,9 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust  to replace characters in a string.
 
-    assert_eq!(
-        replace_chars(&("polygon".as_bytes()), b'y', b'l'),
-        "pollgon".as_bytes().to_vec()
-    );
-    assert_eq!(
-        replace_chars(&("character".as_bytes()), b'c', b'a'),
-        "aharaater".as_bytes().to_vec()
-    );
-    assert_eq!(
-        replace_chars(&("python".as_bytes()), b'l', b'a'),
-        "python".as_bytes().to_vec()
-    );
+    assert_eq!(replace_chars(b"polygon", b'y', b'l'), b"pollgon");
+    assert_eq!(replace_chars(b"character", b'c', b'a'), b"aharaater");
+    assert_eq!(replace_chars(b"python", b'l', b'a'), b"python");
 }
 
 verus! {

--- a/benchmarks/MBPP/verified/task_id_474.rs
+++ b/benchmarks/MBPP/verified/task_id_474.rs
@@ -4,28 +4,22 @@ fn main() {
     // Write a function in Rust  to replace characters in a string.
 
     assert_eq!(
-        replace_chars(&("polygon".chars().collect()), 'y', 'l')
-            .iter()
-            .collect::<String>(),
-        "pollgon"
+        replace_chars(&("polygon".as_bytes()), b'y', b'l'),
+        "pollgon".as_bytes().to_vec()
     );
     assert_eq!(
-        replace_chars(&("character".chars().collect()), 'c', 'a')
-            .iter()
-            .collect::<String>(),
-        "aharaater"
+        replace_chars(&("character".as_bytes()), b'c', b'a'),
+        "aharaater".as_bytes().to_vec()
     );
     assert_eq!(
-        replace_chars(&("python".chars().collect()), 'l', 'a')
-            .iter()
-            .collect::<String>(),
-        "python"
+        replace_chars(&("python".as_bytes()), b'l', b'a'),
+        "python".as_bytes().to_vec()
     );
 }
 
 verus! {
 
-fn replace_chars(str1: &Vec<char>, old_char: char, new_char: char) -> (result: Vec<char>)
+fn replace_chars(str1: &[u8], old_char: u8, new_char: u8) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|

--- a/benchmarks/MBPP/verified/task_id_477.rs
+++ b/benchmarks/MBPP/verified/task_id_477.rs
@@ -3,37 +3,22 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to convert the given string to lower case.
 
-    assert_eq!(
-        to_lowercase(&("InValid".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "invalid"
-    );
-    assert_eq!(
-        to_lowercase(&("TruE".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "true"
-    );
-    assert_eq!(
-        to_lowercase(&("SenTenCE".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "sentence"
-    );
+    assert_eq!(to_lowercase(b"InValid"), b"invalid");
+    assert_eq!(to_lowercase(b"TruE"), b"true");
+    assert_eq!(to_lowercase(b"SenTenCE"), b"sentence");
 }
 
 verus! {
 
-spec fn is_upper_case(c: char) -> bool {
-    c >= 'A' && c <= 'Z'
+spec fn is_upper_case(c: u8) -> bool {
+    c >= 65 && c <= 90
 }
 
-spec fn shift32_spec(c: char) -> char {
-    ((c as u8) + 32) as char
+spec fn shift32_spec(c: u8) -> u8 {
+    (c + 32) as u8
 }
 
-fn to_lowercase(str1: &Vec<char>) -> (result: Vec<char>)
+fn to_lowercase(str1: &[u8]) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|
@@ -43,7 +28,7 @@ fn to_lowercase(str1: &Vec<char>) -> (result: Vec<char>)
                 str1[i]
             }),
 {
-    let mut lower_case: Vec<char> = Vec::with_capacity(str1.len());
+    let mut lower_case: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len()
         invariant
@@ -56,8 +41,8 @@ fn to_lowercase(str1: &Vec<char>) -> (result: Vec<char>)
                     str1[i]
                 }),
     {
-        if (str1[index] >= 'A' && str1[index] <= 'Z') {
-            lower_case.push(((str1[index] as u8) + 32) as char);
+        if (str1[index] >= 65 && str1[index] <= 90) {
+            lower_case.push((str1[index] + 32) as u8);
 
         } else {
             lower_case.push(str1[index]);

--- a/benchmarks/MBPP/verified/task_id_557.rs
+++ b/benchmarks/MBPP/verified/task_id_557.rs
@@ -2,45 +2,30 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to toggle the case of all characters in a string.
 
-    assert_eq!(
-        to_toggle_case(&("Python".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "pYTHON"
-    );
-    assert_eq!(
-        to_toggle_case(&("Pangram".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "pANGRAM"
-    );
-    assert_eq!(
-        to_toggle_case(&("LIttLE".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "liTTle"
-    );
+    assert_eq!(to_toggle_case(b"Python"), b"pYTHON");
+    assert_eq!(to_toggle_case(b"Pangram"), b"pANGRAM");
+    assert_eq!(to_toggle_case(b"LIttLE"), b"liTTle");
 }
 
 verus! {
 
-spec fn is_upper_case(c: char) -> bool {
-    c >= 'A' && c <= 'Z'
+spec fn is_upper_case(c: u8) -> bool {
+    c >= 65 && c <= 90
 }
 
-spec fn shift32_spec(c: char) -> char {
-    ((c as u8) + 32) as char
+spec fn shift32_spec(c: u8) -> u8 {
+    (c + 32) as u8
 }
 
-spec fn is_lower_case(c: char) -> bool {
-    c >= 'a' && c <= 'z'
+spec fn is_lower_case(c: u8) -> bool {
+    c >= 97 && c <= 122
 }
 
-spec fn shift_minus_32_spec(c: char) -> char {
-    ((c as u8) - 32) as char
+spec fn shift_minus_32_spec(c: u8) -> u8 {
+    (c - 32) as u8
 }
 
-spec fn to_toggle_case_spec(s: char) -> char {
+spec fn to_toggle_case_spec(s: u8) -> u8 {
     if is_lower_case(s) {
         shift_minus_32_spec(s)
     } else if is_upper_case(s) {
@@ -50,7 +35,7 @@ spec fn to_toggle_case_spec(s: char) -> char {
     }
 }
 
-fn to_toggle_case(str1: &Vec<char>) -> (toggle_case: Vec<char>)
+fn to_toggle_case(str1: &[u8]) -> (toggle_case: Vec<u8>)
     ensures
         str1@.len() == toggle_case@.len(),
         forall|i: int|
@@ -66,10 +51,10 @@ fn to_toggle_case(str1: &Vec<char>) -> (toggle_case: Vec<char>)
             forall|i: int|
                 0 <= i < index ==> toggle_case[i] == to_toggle_case_spec(#[trigger] str1[i]),
     {
-        if (str1[index] >= 'a' && str1[index] <= 'z') {
-            toggle_case.push(((str1[index] as u8) - 32) as char);
-        } else if (str1[index] >= 'A' && str1[index] <= 'Z') {
-            toggle_case.push(((str1[index] as u8) + 32) as char);
+        if (str1[index] >= 97 && str1[index] <= 122) {
+            toggle_case.push((str1[index] - 32) as u8);
+        } else if (str1[index] >= 65 && str1[index] <= 90) {
+            toggle_case.push((str1[index] + 32) as u8);
         } else {
             toggle_case.push(str1[index]);
         }

--- a/benchmarks/MBPP/verified/task_id_576_v2.rs
+++ b/benchmarks/MBPP/verified/task_id_576_v2.rs
@@ -1,5 +1,4 @@
 /*This is a slightly simpler version of proof provided by Chris Hawblitzel*/
-
 use vstd::prelude::*;
 
 fn main() {
@@ -46,8 +45,8 @@ fn sub_array_at_index(main: &Vec<i32>, sub: &Vec<i32>, idx: usize) -> (result: b
 }
 
 spec fn is_subrange_at(main: Seq<i32>, sub: Seq<i32>, i: int) -> bool {
-    sub =~= main.subrange(i, i+sub.len())
-} 
+    sub =~= main.subrange(i, i + sub.len())
+}
 
 fn is_sub_array(main: &Vec<i32>, sub: &Vec<i32>) -> (result: bool)
     ensures
@@ -62,7 +61,7 @@ fn is_sub_array(main: &Vec<i32>, sub: &Vec<i32>) -> (result: bool)
         invariant
             sub.len() <= main.len(),
             0 <= index <= (main.len() - sub.len()) + 1,
-            forall |k:int| 0<= k < index ==> !is_subrange_at(main@, sub@, k),
+            forall|k: int| 0 <= k < index ==> !is_subrange_at(main@, sub@, k),
     {
         if (sub_array_at_index(&main, &sub, index)) {
             assert(is_subrange_at(main@, sub@, index as int));

--- a/benchmarks/MBPP/verified/task_id_602.rs
+++ b/benchmarks/MBPP/verified/task_id_602.rs
@@ -3,20 +3,14 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to find the first repeated character in a given string.
 
-    assert_eq!(
-        first_repeated_char(&("abcabc".chars().collect())),
-        Some((0, 'a'))
-    );
-    assert_eq!(first_repeated_char(&("abc".chars().collect())), None);
-    assert_eq!(
-        first_repeated_char(&("123123".chars().collect())),
-        Some((0, '1'))
-    );
+    assert_eq!(first_repeated_char(b"abcabc"), Some((0, b'a')));
+    assert_eq!(first_repeated_char(b"abc"), None);
+    assert_eq!(first_repeated_char(b"123123"), Some((0, b'1')));
 }
 
 verus! {
 
-pub open spec fn count_frequency_rcr(seq: Seq<char>, key: char) -> int
+pub open spec fn count_frequency_rcr(seq: Seq<u8>, key: u8) -> int
     decreases seq.len(),
 {
     if seq.len() == 0 {
@@ -30,7 +24,7 @@ pub open spec fn count_frequency_rcr(seq: Seq<char>, key: char) -> int
     }
 }
 
-fn count_frequency(arr: &Vec<char>, key: char) -> (frequency: usize)
+fn count_frequency(arr: &[u8], key: u8) -> (frequency: usize)
     ensures
         count_frequency_rcr(arr@, key) == frequency,
 {
@@ -52,11 +46,11 @@ fn count_frequency(arr: &Vec<char>, key: char) -> (frequency: usize)
     counter
 }
 
-fn first_repeated_char(str1: &Vec<char>) -> (repeated_char: Option<(usize, char)>)
+fn first_repeated_char(str1: &[u8]) -> (repeated_char: Option<(usize, u8)>)
     ensures
         if let Some((idx, rp_char)) = repeated_char {
             &&& str1@.take(idx as int) =~= str1@.take(idx as int).filter(
-                |x: char| count_frequency_rcr(str1@, x) <= 1,
+                |x: u8| count_frequency_rcr(str1@, x) <= 1,
             )
             &&& count_frequency_rcr(str1@, rp_char) > 1
         } else {
@@ -65,15 +59,15 @@ fn first_repeated_char(str1: &Vec<char>) -> (repeated_char: Option<(usize, char)
         },
 {
     let input_len = str1.len();
-    assert(str1@.take(0int).filter(|x: char| count_frequency_rcr(str1@, x) > 1) == Seq::<
-        char,
+    assert(str1@.take(0int).filter(|x: u8| count_frequency_rcr(str1@, x) > 1) == Seq::<
+        u8,
     >::empty());
     let mut index = 0;
     while index < str1.len()
         invariant
             0 <= index <= str1.len(),
             str1@.take(index as int) =~= str1@.take(index as int).filter(
-                |x: char| count_frequency_rcr(str1@, x) <= 1,
+                |x: u8| count_frequency_rcr(str1@, x) <= 1,
             ),
     {
         if count_frequency(&str1, str1[index]) > 1 {

--- a/benchmarks/MBPP/verified/task_id_624.rs
+++ b/benchmarks/MBPP/verified/task_id_624.rs
@@ -3,37 +3,22 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to convert a given string to uppercase.
 
-    assert_eq!(
-        to_uppercase(&("person".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "PERSON"
-    );
-    assert_eq!(
-        to_uppercase(&("final".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "FINAL"
-    );
-    assert_eq!(
-        to_uppercase(&("Valid".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "VALID"
-    );
+    assert_eq!(to_uppercase(b"person"), b"PERSON");
+    assert_eq!(to_uppercase(b"final"), b"FINAL");
+    assert_eq!(to_uppercase(b"Valid"), b"VALID");
 }
 
 verus! {
 
-spec fn is_lower_case(c: char) -> bool {
-    c >= 'a' && c <= 'z'
+spec fn is_lower_case(c: u8) -> bool {
+    c >= 97 && c <= 122
 }
 
-spec fn shift_minus_32_spec(c: char) -> char {
-    ((c as u8) - 32) as char
+spec fn shift_minus_32_spec(c: u8) -> u8 {
+    (c - 32) as u8
 }
 
-fn to_uppercase(str1: &Vec<char>) -> (result: Vec<char>)
+fn to_uppercase(str1: &[u8]) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|i: int|
@@ -43,7 +28,7 @@ fn to_uppercase(str1: &Vec<char>) -> (result: Vec<char>)
                 str1[i]
             })),
 {
-    let mut upper_case: Vec<char> = Vec::with_capacity(str1.len());
+    let mut upper_case: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len()
         invariant
@@ -56,8 +41,8 @@ fn to_uppercase(str1: &Vec<char>) -> (result: Vec<char>)
                     str1[i]
                 })),
     {
-        if (str1[index] >= 'a' && str1[index] <= 'z') {
-            upper_case.push(((str1[index] as u8) - 32) as char);
+        if (str1[index] >= 97 && str1[index] <= 122) {
+            upper_case.push((str1[index] - 32) as u8);
         } else {
             upper_case.push(str1[index]);
         }

--- a/benchmarks/MBPP/verified/task_id_732.rs
+++ b/benchmarks/MBPP/verified/task_id_732.rs
@@ -1,45 +1,38 @@
 use vstd::prelude::*;
 
 fn main() {
-    // Write a function in Rust to check whether all the characters are same or not.
+    // Write a function in Rust to replace all occurrences of spaces, commas or dots with a colon.
 
     assert_eq!(
-        replace_with_colon(&("Python language, Programming language.".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "Python:language::Programming:language:"
+        replace_with_colon(b"Python language, Programming language."),
+        b"Python:language::Programming:language:"
     );
+    assert_eq!(replace_with_colon(b"a b c,d e f"), b"a:b:c:d:e:f");
     assert_eq!(
-        replace_with_colon(&("a b c,d e f".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "a:b:c:d:e:f"
-    );
-    assert_eq!(
-        replace_with_colon(&("ram reshma,ram rahim".chars().collect()))
-            .iter()
-            .collect::<String>(),
-        "ram:reshma:ram:rahim"
+        replace_with_colon(b"ram reshma,ram rahim"),
+        b"ram:reshma:ram:rahim"
     );
 }
 
 verus! {
 
-spec fn is_space_comma_dot_spec(c: char) -> bool {
-    (c == ' ') || (c == ',') || (c == '.')
+// ASCII --> space=32, comma=44 , dot=46 , colon=58
+spec fn is_space_comma_dot_spec(c: u8) -> bool {
+    (c == 32) || (c == 44) || (c == 46)
 }
 
-fn replace_with_colon(str1: &Vec<char>) -> (result: Vec<char>)
+fn replace_with_colon(str1: &[u8]) -> (result: Vec<u8>)
     ensures
         str1@.len() == result@.len(),
         forall|k: int|
             0 <= k < result.len() ==> #[trigger] result[k] == (if is_space_comma_dot_spec(str1[k]) {
-                ':'
+                58  //ASCII -> colon=58
+
             } else {
                 str1[k]
             }),
 {
-    let mut result: Vec<char> = Vec::with_capacity(str1.len());
+    let mut result: Vec<u8> = Vec::with_capacity(str1.len());
     let mut index = 0;
     while index < str1.len()
         invariant
@@ -47,13 +40,14 @@ fn replace_with_colon(str1: &Vec<char>) -> (result: Vec<char>)
             result@.len() == index,
             forall|k: int|
                 0 <= k < index ==> #[trigger] result[k] == (if is_space_comma_dot_spec(str1[k]) {
-                    ':'
+                    58  //ASCII -> colon=58
+
                 } else {
                     str1[k]
                 }),
     {
-        if ((str1[index] == ' ') || (str1[index] == ',') || (str1[index] == '.')) {
-            result.push(':');
+        if ((str1[index] == 32) || (str1[index] == 44) || (str1[index] == 46)) {
+            result.push(58);  //ASCII -> colon=58
         } else {
             result.push(str1[index]);
         }

--- a/benchmarks/MBPP/verified/task_id_741.rs
+++ b/benchmarks/MBPP/verified/task_id_741.rs
@@ -3,14 +3,14 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to check whether all the characters are same or not.
 
-    assert!(!all_characters_same(&("python".chars().collect())));
-    assert!(all_characters_same(&("aaa".chars().collect())));
-    assert!(!all_characters_same(&("data".chars().collect())));
+    assert!(!all_characters_same(b"python"));
+    assert!(all_characters_same(b"aaa"));
+    assert!(!all_characters_same(b"data"));
 }
 
 verus! {
 
-fn all_characters_same(char_arr: &Vec<char>) -> (result: bool)
+fn all_characters_same(char_arr: &[u8]) -> (result: bool)
     ensures
         result == (forall|i: int|
             1 <= i < char_arr@.len() ==> char_arr[0] == #[trigger] char_arr[i]),

--- a/benchmarks/MBPP/verified/task_id_764.rs
+++ b/benchmarks/MBPP/verified/task_id_764.rs
@@ -3,19 +3,19 @@ use vstd::prelude::*;
 fn main() {
     // Write a function in Rust to count number of digits in a given string.
 
-    assert_eq!(count_digits(&("program2bedone".chars().collect())), 1);
-    assert_eq!(count_digits(&("3wonders".chars().collect())), 1);
-    assert_eq!(count_digits(&("123".chars().collect())), 3);
-    assert_eq!(count_digits(&("3wond-1ers2".chars().collect())), 3);
+    assert_eq!(count_digits(b"program2bedone"), 1);
+    assert_eq!(count_digits(b"3wonders"), 1);
+    assert_eq!(count_digits(b"123"), 3);
+    assert_eq!(count_digits(b"3wond-1ers2"), 3);
 }
 
 verus! {
 
-spec fn is_digit(c: char) -> bool {
-    (c as u8) >= 48 && (c as u8) <= 57
+spec fn is_digit(c: u8) -> bool {
+    (c >= 48 && c <= 57)
 }
 
-spec fn count_digits_recursively(seq: Seq<char>) -> int
+spec fn count_digits_recursively(seq: Seq<u8>) -> int
     decreases seq.len(),
 {
     if seq.len() == 0 {
@@ -29,21 +29,21 @@ spec fn count_digits_recursively(seq: Seq<char>) -> int
     }
 }
 
-fn count_digits(text: &Vec<char>) -> (count: usize)
+fn count_digits(text: &[u8]) -> (count: usize)
     ensures
         0 <= count <= text.len(),
         count_digits_recursively(text@) == count,
 {
     let mut count = 0;
-
     let mut index = 0;
+
     while index < text.len()
         invariant
             0 <= index <= text.len(),
             0 <= count <= index,
             count == count_digits_recursively(text@.subrange(0, index as int)),
     {
-        if ((text[index] as u8) >= 48 && (text[index] as u8) <= 57) {
+        if (text[index] >= 48 && text[index] <= 57) {
             count += 1;
         }
         index += 1;

--- a/benchmarks/MBPP/verified/verified_tasks_list.csv
+++ b/benchmarks/MBPP/verified/verified_tasks_list.csv
@@ -61,7 +61,7 @@
 629,Write a function in Rust to find even numbers from a list of numbers.
 644,Write a function in Rust to reverse an array upto a given position.
 728,"Write a function in Rust takes as input two lists [a_1,...,a_n] [b_1,...,b_n] and returns [a_1+b_1,...,a_n+b_n]."
-732,Write a function in Rust to check whether all the characters are same or not.
+732,Write a function in Rust to replace all occurrences of spaces commas or dots with a colon.
 733,Write a function in Rust to find the index of the first occurrence of a given number in a sorted array.
 741,Write a function in Rust to check whether all the characters are same or not.
 743,Write a method in Rust to rotate a given list by specified N number of items to the right direction.

--- a/benchmarks/MBPP/verified/verify_all.sh
+++ b/benchmarks/MBPP/verified/verify_all.sh
@@ -3,8 +3,9 @@
 ################################################################################################
 # This script verifies all *.rs files inside a directory using verus.
 #
-# To run this script, make sure verus is installed and available in the command line
+# To run this script, make sure verus and verusfmt are installed and available in the command line
 # To install verus, follow this: [https://github.com/verus-lang/verus/blob/main/INSTALL.md]
+# To install verusfmt follow this: [https://github.com/verus-lang/verusfmt]
 #
 # To chech verus installation: >> verus --version
 #
@@ -18,6 +19,8 @@ SEARCH_DIR="${1:-.}"
 find "$SEARCH_DIR" -type f -name "*.rs" | while read -r rs_file; do
   echo "[Start] verifing: $rs_file..."
   
+  # format the source first
+  verusfmt "$rs_file"
   # verify with Verus with --multiple-errors
   verus "$rs_file" --multiple-errors 20
   

--- a/benchmarks/MBPP/verified/verify_compile_run_all.sh
+++ b/benchmarks/MBPP/verified/verify_compile_run_all.sh
@@ -5,8 +5,9 @@
 # inside a directory using verus and runs the test cases.
 # It also removes all compiled files after test execution.
 #
-# To run this script, make sure verus is installed and available in the command line
+# To run this script, make sure verus and verusfmt are installed and available in the command line
 # To install verus, follow this: [https://github.com/verus-lang/verus/blob/main/INSTALL.md]
+# To install verusfmt follow this: [https://github.com/verus-lang/verusfmt]
 #
 # To chech verus installation, try: >> verus --version
 #
@@ -20,7 +21,10 @@ find "$SEARCH_DIR" -type f -name "*.rs" | while read -r rs_file; do
   echo "[Start] verifing and compiling: $rs_file..."
   
   base_name=$(basename "$rs_file" .rs)
-  # verify and compile with Verus 
+  
+  # format the source first
+  verusfmt "$rs_file"
+  # verify and compile with Verus
   verus "$rs_file" --compile --multiple-errors 20
 
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
This pull request refactors the MBPP Benchmark problems. Changes are as follows:

- Change the `char` type to `u8` in implementation, and specifications both in verified/unverified tasks.
- Change input types from `Vec<char>` to `[u8]`, to represent an `ASCII` character array or String
- Change test cases to incorporate the type changes on verified implementation 
- The `char` has been updated to tasks`:  [18, 113, 230, 424, 454, 461, 474, 477, 557, 602, 624, 764, 732, 741]`
- Verification scripts have been updated to format source with the `verusfmt` before verifying/compiling
