### PR TITLE
Add decreases clauses for loops

### DIFF
--- a/benchmarks/MBPP/verified/task_id_105.rs
+++ b/benchmarks/MBPP/verified/task_id_105.rs
@@ -37,6 +37,8 @@ fn count_true(arr: &Vec<bool>) -> (count: u64)
             0 <= index <= arr.len(),
             0 <= counter <= index,
             count_boolean(arr@.subrange(0, index as int)) == counter,
+        decreases 
+            arr.len() - index,
     {
         if (arr[index]) {
             counter += 1;

--- a/benchmarks/MBPP/verified/task_id_113.rs
+++ b/benchmarks/MBPP/verified/task_id_113.rs
@@ -30,6 +30,8 @@ fn is_integer(text: &Vec<char>) -> (result: bool)
         invariant
             0 <= index <= text.len(),
             forall|i: int| 0 <= i < index ==> (#[trigger] is_digit_sepc(text[i])),
+        decreases
+            text.len() - index,
     {
         if (!is_digit(text[index])) {
             return false;

--- a/benchmarks/MBPP/verified/task_id_133.rs
+++ b/benchmarks/MBPP/verified/task_id_133.rs
@@ -42,6 +42,8 @@ fn sum_negatives(arr: &Vec<i64>) -> (sum_neg: i128)
                     #[trigger] arr@.subrange(0, j),
                 )) <= 0),
             sum_negative_to(arr@.subrange(0, index as int)) == sum_neg,
+        decreases
+            arr.len() - index,
     {
         if (arr[index] < 0) {
             sum_neg = sum_neg + (arr[index] as i128);

--- a/benchmarks/MBPP/verified/task_id_142.rs
+++ b/benchmarks/MBPP/verified/task_id_142.rs
@@ -65,6 +65,8 @@ fn count_identical_position(arr1: &Vec<i32>, arr2: &Vec<i32>, arr3: &Vec<i32>) -
                 arr2@.subrange(0, index as int),
                 arr3@.subrange(0, index as int),
             ) == count,
+        decreases
+            arr1.len() - index,
     {
         if arr1[index] == arr2[index] && arr2[index] == arr3[index] {
             count += 1;

--- a/benchmarks/MBPP/verified/task_id_145.rs
+++ b/benchmarks/MBPP/verified/task_id_145.rs
@@ -28,6 +28,8 @@ fn max_difference(arr: &Vec<i32>) -> (diff: i32)
             min_val <= max_val,
             forall|i: int| 0 <= i < arr.len() ==> i32::MIN / 2 < #[trigger] arr[i] < i32::MAX / 2,
             forall|k: int| 0 <= k < index ==> min_val <= arr[k] && arr[k] <= max_val,
+        decreases
+            arr.len() - index,
     {
         if (arr[index] < min_val) {
             min_val = arr[index];

--- a/benchmarks/MBPP/verified/task_id_161.rs
+++ b/benchmarks/MBPP/verified/task_id_161.rs
@@ -36,6 +36,9 @@ fn contains(str: &Vec<i32>, key: i32) -> (result: bool)
     while i < str.len()
         invariant
             forall|m: int| 0 <= m < i ==> (str[m] != key),
+    decreases
+        str.len() - i,
+    
     {
         if (str[i] == key) {
             return true;
@@ -69,6 +72,8 @@ fn remove_elements(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 0 <= k < index ==> (arr2@.contains(#[trigger] arr1[k]) || output_str@.contains(
                     #[trigger] arr1[k],
                 )),
+    decreases
+        arr1.len() - index,
     {
         if (!contains(arr2, arr1[index])) {
             proof {

--- a/benchmarks/MBPP/verified/task_id_170.rs
+++ b/benchmarks/MBPP/verified/task_id_170.rs
@@ -49,6 +49,8 @@ fn sum_range_list(arr: &Vec<i64>, start: usize, end: usize) -> (sum: i128)
                 start <= j <= index ==> (i64::MIN * index <= (sum_to(
                     #[trigger] arr@.subrange(start as int, j),
                 )) <= i64::MAX * index),
+        decreases
+            _end - index,
     {
         assert(arr@.subrange(start as int, index as int) =~= arr@.subrange(
             start as int,

--- a/benchmarks/MBPP/verified/task_id_18.rs
+++ b/benchmarks/MBPP/verified/task_id_18.rs
@@ -51,6 +51,8 @@ fn contains(str: &Vec<char>, key: char) -> (result: bool)
     while i < str.len()
         invariant
             forall|m: int| 0 <= m < i ==> (str[m] != key),
+        decreases
+            str.len() - i,
     {
         if (str[i] == key) {
             return true;
@@ -84,6 +86,8 @@ fn remove_chars(str1: &Vec<char>, str2: &Vec<char>) -> (result: Vec<char>)
                 0 <= k < index ==> (str2@.contains(#[trigger] str1[k]) || output_str@.contains(
                     #[trigger] str1[k],
                 )),
+        decreases
+            str1.len() - index,
     {
         if (!contains(str2, str1[index])) {
             proof {

--- a/benchmarks/MBPP/verified/task_id_2.rs
+++ b/benchmarks/MBPP/verified/task_id_2.rs
@@ -27,6 +27,8 @@ fn contains(arr: &Vec<i32>, key: i32) -> (result: bool)
     while i < arr.len()
         invariant
             forall|m: int| 0 <= m < i ==> (arr[m] != key),
+        decreases
+            arr.len() - i,
     {
         if (arr[i] == key) {
             return true;
@@ -55,6 +57,8 @@ fn shared_elements(list1: &Vec<i32>, list2: &Vec<i32>) -> (shared: Vec<i32>)
                     #[trigger] shared[i],
                 )),
             forall|m: int, n: int| 0 <= m < n < shared.len() ==> shared[m] != shared[n],
+        decreases
+            list1.len() - index,
     {
         if (contains(list2, list1[index]) && !contains(&shared, list1[index])) {
             shared.push(list1[index]);

--- a/benchmarks/MBPP/verified/task_id_230.rs
+++ b/benchmarks/MBPP/verified/task_id_230.rs
@@ -47,6 +47,8 @@ fn replace_blanks_with_chars(str1: &Vec<char>, ch: char) -> (result: Vec<char>)
                 } else {
                     str1[k]
                 }),
+        decreases
+            str1.len() - index, 
     {
         if (str1[index] == ' ') {
             out_str.push(ch);

--- a/benchmarks/MBPP/verified/task_id_240.rs
+++ b/benchmarks/MBPP/verified/task_id_240.rs
@@ -34,6 +34,8 @@ fn replace_last_element(first: &Vec<i32>, second: &Vec<i32>) -> (replaced_list: 
             first_end == first.len() - 1,
             0 <= index <= first_end,
             replaced_list@ =~= first@.subrange(0, index as int),
+        decreases
+            first_end - index,
     {
         replaced_list.push(first[index]);
         index += 1;
@@ -45,6 +47,8 @@ fn replace_last_element(first: &Vec<i32>, second: &Vec<i32>) -> (replaced_list: 
             replaced_list@ =~= first@.subrange(0, first.len() - 1).add(
                 second@.subrange(0, index as int),
             ),
+        decreases
+            second.len() - index,
     {
         replaced_list.push(second[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_249.rs
+++ b/benchmarks/MBPP/verified/task_id_249.rs
@@ -27,6 +27,9 @@ fn contains(arr: &Vec<i32>, key: i32) -> (result: bool)
     while i < arr.len()
         invariant
             forall|m: int| 0 <= m < i ==> (arr[m] != key),
+        decreases
+            arr.len() - i,
+    
     {
         if (arr[i] == key) {
             return true;
@@ -54,6 +57,8 @@ fn intersection(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 0 <= i < output_arr.len() ==> (arr1@.contains(#[trigger] output_arr[i])
                     && arr2@.contains(#[trigger] output_arr[i])),
             forall|m: int, n: int| 0 <= m < n < output_arr.len() ==> output_arr[m] != output_arr[n],
+        decreases
+            arr1.len() - index,
     {
         if (contains(arr2, arr1[index]) && !contains(&output_arr, arr1[index])) {
             output_arr.push(arr1[index]);

--- a/benchmarks/MBPP/verified/task_id_251.rs
+++ b/benchmarks/MBPP/verified/task_id_251.rs
@@ -35,6 +35,8 @@ fn insert_before_each(arr: &Vec<i32>, elem: i32) -> (result: Vec<i32>)
             result@.len() == index * 2,
             forall|k: int| 0 <= k < index ==> #[trigger] result[2 * k] == elem,
             forall|k: int| 0 <= k < index ==> #[trigger] result[2 * k + 1] == arr[k],
+        decreases
+            arr.len() - index,
     {
         result.push(elem);
         result.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_261.rs
+++ b/benchmarks/MBPP/verified/task_id_261.rs
@@ -46,6 +46,8 @@ fn element_wise_division(arr1: &Vec<u32>, arr2: &Vec<u32>) -> (result: Vec<u32>)
                     <= u32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] / arr2[k]),
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] / arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_262.rs
+++ b/benchmarks/MBPP/verified/task_id_262.rs
@@ -34,6 +34,8 @@ fn split_array(list: &Vec<i32>, l: usize) -> (new_list: (Vec<i32>, Vec<i32>))
             0 < l < list@.len(),
             0 <= index <= l,
             part1@ =~= list@.subrange(0, index as int),
+        decreases
+            l - index,
     {
         part1.push(list[index]);
         index += 1;
@@ -44,6 +46,8 @@ fn split_array(list: &Vec<i32>, l: usize) -> (new_list: (Vec<i32>, Vec<i32>))
         invariant
             l <= index <= list.len(),
             part2@ =~= list@.subrange(l as int, index as int),
+        decreases
+            list.len() - index,
     {
         part2.push(list[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_273.rs
+++ b/benchmarks/MBPP/verified/task_id_273.rs
@@ -40,6 +40,8 @@ fn element_wise_subtract(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 (0 <= i < arr1.len()) ==> (i32::MIN <= #[trigger] (arr1[i] - arr2[i]) <= i32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] - arr2[k]),
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] - arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_282.rs
+++ b/benchmarks/MBPP/verified/task_id_282.rs
@@ -38,6 +38,9 @@ fn element_wise_subtract(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 (0 <= i < arr1.len()) ==> (i32::MIN <= #[trigger] (arr1[i] - arr2[i]) <= i32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] - arr2[k]),
+    decreases
+        arr1.len() - index,
+    
     {
         output_arr.push((arr1[index] - arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_284.rs
+++ b/benchmarks/MBPP/verified/task_id_284.rs
@@ -19,6 +19,8 @@ fn all_elements_equals(arr: &Vec<i32>, element: i32) -> (result: bool)
         invariant
             0 <= index <= arr.len(),
             forall|k: int| 0 <= k < index ==> (arr[k] == element),
+        decreases
+            arr.len() - index,
     {
         if arr[index] != element {
             return false;

--- a/benchmarks/MBPP/verified/task_id_290.rs
+++ b/benchmarks/MBPP/verified/task_id_290.rs
@@ -43,6 +43,8 @@ fn max_length_list(seq: &Vec<Vec<i32>>) -> (max_list: &Vec<i32>)
             0 <= index <= seq.len(),
             forall|k: int| 0 <= k < index ==> max_list.len() >= #[trigger] (seq[k]).len(),
             exists|k: int| 0 <= k < index && max_list@ =~= #[trigger] (seq[k]@),
+        decreases
+            seq.len() - index,
     {
         if ((seq[index]).len() > max_list.len()) {
             max_list = &seq[index];

--- a/benchmarks/MBPP/verified/task_id_3.rs
+++ b/benchmarks/MBPP/verified/task_id_3.rs
@@ -33,6 +33,8 @@ fn is_non_prime(n: u64) -> (result: bool)
         invariant
             2 <= index,
             forall|k: int| 2 <= k < index ==> !is_divisible(n as int, k),
+        decreases
+            n - index,
     {
         if ((n % index) == 0) {
             assert(is_divisible(n as int, index as int));

--- a/benchmarks/MBPP/verified/task_id_307.rs
+++ b/benchmarks/MBPP/verified/task_id_307.rs
@@ -25,6 +25,8 @@ fn list_deep_clone(arr: &Vec<u64>) -> (copied: Vec<u64>)
             0 <= index <= arr.len(),
             copied_array.len() == index,
             forall|i: int| (0 <= i < index) ==> arr[i] == copied_array[i],
+        decreases
+            arr.len() - index,
     {
         copied_array.push(arr[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_399.rs
+++ b/benchmarks/MBPP/verified/task_id_399.rs
@@ -36,6 +36,8 @@ fn bit_wise_xor(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
             output_arr.len() == index,
             forall|k: int|
                 0 <= k < index ==> output_arr[k] == #[trigger] arr1[k] ^ #[trigger] arr2[k],
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] ^ arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_412.rs
+++ b/benchmarks/MBPP/verified/task_id_412.rs
@@ -23,6 +23,8 @@ fn remove_odds(arr: &Vec<u32>) -> (even_list: Vec<u32>)
         invariant
             0 <= index <= arr.len(),
             even_list@ == arr@.take(index as int).filter(|x: u32| x % 2 == 0),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] % 2 == 0) {
             even_list.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_414.rs
+++ b/benchmarks/MBPP/verified/task_id_414.rs
@@ -19,6 +19,8 @@ fn contains(arr: &Vec<i32>, key: i32) -> (result: bool)
         invariant
             0 <= i <= arr.len(),
             forall|m: int| 0 <= m < i ==> (arr[m] != key),
+        decreases
+            arr.len() - i,
     {
         if (arr[i] == key) {
             return true;
@@ -37,6 +39,8 @@ fn any_value_exists(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: bool)
         invariant
             0 <= index <= arr1.len(),
             forall|k: int| 0 <= k < index ==> !arr2@.contains(#[trigger] arr1[k]),
+        decreases
+            arr1.len() - index,
     {
         if (contains(arr2, arr1[index])) {
             return true;

--- a/benchmarks/MBPP/verified/task_id_424.rs
+++ b/benchmarks/MBPP/verified/task_id_424.rs
@@ -52,6 +52,8 @@ fn extract_rear_chars(s: &Vec<Vec<char>>) -> (result: Vec<char>)
             rear_chars.len() == index,
             forall|i: int| 0 <= i < s.len() ==> #[trigger] s[i].len() > 0,
             forall|k: int| 0 <= k < index ==> rear_chars[k] == #[trigger] s[k][s[k].len() - 1],
+        decreases
+            s.len() - index,
     {
         let seq = &s[index];
         rear_chars.push(seq[seq.len() - 1]);

--- a/benchmarks/MBPP/verified/task_id_426.rs
+++ b/benchmarks/MBPP/verified/task_id_426.rs
@@ -29,6 +29,8 @@ fn filter_odd_numbers(arr: &Vec<u32>) -> (odd_list: Vec<u32>)
         invariant
             0 <= index <= arr.len(),
             odd_list@ == arr@.take(index as int).filter(|x: u32| x % 2 != 0),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] % 2 != 0) {
             odd_list.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_431.rs
+++ b/benchmarks/MBPP/verified/task_id_431.rs
@@ -23,6 +23,8 @@ fn has_common_element(list1: &Vec<i32>, list2: &Vec<i32>) -> (result: bool)
         invariant
             0 <= i <= list1.len(),
             forall|k: int, j: int| 0 <= k < i && 0 <= j < list2.len() ==> (list1[k] != list2[j]),
+        decreases
+            list1.len() - i,
     {
         let mut j = 0;
         while j < list2.len()
@@ -30,6 +32,8 @@ fn has_common_element(list1: &Vec<i32>, list2: &Vec<i32>) -> (result: bool)
                 0 <= i < list1.len(),
                 0 <= j <= list2.len(),
                 forall|k: int| 0 <= k < j ==> (list1[i as int] != list2[k]),
+            decreases
+                list2.len() - j,
         {
             if list1[i] == list2[j] {
                 return true;

--- a/benchmarks/MBPP/verified/task_id_433.rs
+++ b/benchmarks/MBPP/verified/task_id_433.rs
@@ -19,6 +19,8 @@ fn is_greater(arr: &Vec<i32>, number: i32) -> (result: bool)
         invariant
             0 <= i <= arr.len(),
             forall|k: int| 0 <= k < i ==> number > arr[k],
+        decreases   
+            arr.len() - i,
     {
         if number <= arr[i] {
             return false;

--- a/benchmarks/MBPP/verified/task_id_436.rs
+++ b/benchmarks/MBPP/verified/task_id_436.rs
@@ -23,6 +23,8 @@ fn find_negative_numbers(arr: &Vec<i32>) -> (negative_list: Vec<i32>)
         invariant
             0 <= index <= arr.len(),
             negative_list@ == arr@.take(index as int).filter(|x: i32| x < 0),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] < 0) {
             negative_list.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_445.rs
+++ b/benchmarks/MBPP/verified/task_id_445.rs
@@ -49,6 +49,8 @@ fn element_wise_multiplication(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec
                 (0 <= i < arr1.len()) ==> (i32::MIN <= #[trigger] (arr1[i] * arr2[i]) <= i32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] * arr2[k]),
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] * arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_447.rs
+++ b/benchmarks/MBPP/verified/task_id_447.rs
@@ -39,6 +39,8 @@ fn cube_element(nums: &Vec<i32>) -> (cubed: Vec<i32>)
                     * #[trigger] nums[k] <= i32::MAX),
             forall|k: int|
                 0 <= k < i ==> (#[trigger] cubed_array[k] == nums[k] * nums[k] * nums[k]),
+        decreases
+            nums.len() - i,
     {
         cubed_array.push(nums[i] * nums[i] * nums[i]);
         i += 1;

--- a/benchmarks/MBPP/verified/task_id_454.rs
+++ b/benchmarks/MBPP/verified/task_id_454.rs
@@ -19,6 +19,8 @@ fn contains_z(text: &Vec<char>) -> (result: bool)
         invariant
             0 <= index <= text.len(),
             forall|k: int| 0 <= k < index ==> (text[k] != 'Z' && text[k] != 'z'),
+        decreases
+            text.len() - index,
     {
         if text[index] == 'Z' || text[index] == 'z' {
             return true;

--- a/benchmarks/MBPP/verified/task_id_457.rs
+++ b/benchmarks/MBPP/verified/task_id_457.rs
@@ -35,6 +35,8 @@ fn min_sublist(seq: &Vec<Vec<i32>>) -> (min_list: &Vec<i32>)
             0 <= index <= seq.len(),
             forall|k: int| 0 <= k < index ==> min_list.len() <= #[trigger] (seq[k]).len(),
             exists|k: int| 0 <= k < index && min_list@ =~= #[trigger] (seq[k]@),
+        decreases
+            seq.len() - index,
     {
         if ((seq[index]).len() < min_list.len()) {
             min_list = &seq[index];

--- a/benchmarks/MBPP/verified/task_id_460.rs
+++ b/benchmarks/MBPP/verified/task_id_460.rs
@@ -28,6 +28,8 @@ fn get_first_elements(arr: &Vec<Vec<i32>>) -> (result: Vec<i32>)
             first_elem_arr.len() == index,
             forall|i: int| 0 <= i < arr.len() ==> #[trigger] arr[i].len() > 0,
             forall|k: int| 0 <= k < index ==> #[trigger] first_elem_arr[k] == #[trigger] arr[k][0],
+        decreases
+            arr.len() - index,
     {
         let seq = &arr[index];
         assert(seq.len() > 0);

--- a/benchmarks/MBPP/verified/task_id_461.rs
+++ b/benchmarks/MBPP/verified/task_id_461.rs
@@ -45,6 +45,8 @@ fn count_uppercase(text: &Vec<char>) -> (count: u64)
             0 <= index <= text.len(),
             0 <= count <= index,
             count_uppercase_recursively(text@.subrange(0, index as int)) == count,
+        decreases
+            text.len() - index,
     {
         if ((text[index] as u32) >= 65 && (text[index] as u32) <= 90) {
             count += 1;

--- a/benchmarks/MBPP/verified/task_id_472.rs
+++ b/benchmarks/MBPP/verified/task_id_472.rs
@@ -24,6 +24,8 @@ fn contains_consecutive_numbers(arr: &Vec<i32>) -> (is_consecutive: bool)
             0 <= index <= arr.len() - 1,
             forall|k: int| 0 <= k < arr.len() ==> (0 <= #[trigger] arr[k] + 1 < i32::MAX),
             forall|k: int, l: int| (0 <= k < l <= index && l == k + 1) ==> (arr[k] + 1 == arr[l]),
+        decreases
+            arr.len() - 1 - index,
     {
         if (arr[index] + 1 != arr[index + 1]) {
             return false;

--- a/benchmarks/MBPP/verified/task_id_474.rs
+++ b/benchmarks/MBPP/verified/task_id_474.rs
@@ -47,6 +47,8 @@ fn replace_chars(str1: &Vec<char>, old_char: char, new_char: char) -> (result: V
                 } else {
                     str1[k]
                 }),
+        decreases
+            str1.len() - index,
     {
         if str1[index] == old_char {
             result_str.push(new_char);

--- a/benchmarks/MBPP/verified/task_id_476.rs
+++ b/benchmarks/MBPP/verified/task_id_476.rs
@@ -50,6 +50,8 @@ fn sum_min_max(arr: &Vec<i32>) -> (sum: i32)
             i32::MIN / 2 < max_val < i32::MAX / 2,
             max_val == max_rcur(arr@.subrange(0, index as int)),
             min_val == min_rcur(arr@.subrange(0, index as int)),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] <= min_val) {
             min_val = arr[index];

--- a/benchmarks/MBPP/verified/task_id_477.rs
+++ b/benchmarks/MBPP/verified/task_id_477.rs
@@ -55,6 +55,8 @@ fn to_lowercase(str1: &Vec<char>) -> (result: Vec<char>)
                 } else {
                     str1[i]
                 }),
+        decreases
+            str1.len() - index,
     {
         if (str1[index] >= 'A' && str1[index] <= 'Z') {
             lower_case.push(((str1[index] as u8) + 32) as char);

--- a/benchmarks/MBPP/verified/task_id_554.rs
+++ b/benchmarks/MBPP/verified/task_id_554.rs
@@ -23,6 +23,8 @@ fn find_odd_numbers(arr: &Vec<u32>) -> (odd_numbers: Vec<u32>)
         invariant
             0 <= index <= arr.len(),
             odd_numbers@ == arr@.take(index as int).filter(|x: u32| x % 2 != 0),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] % 2 != 0) {
             odd_numbers.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_557.rs
+++ b/benchmarks/MBPP/verified/task_id_557.rs
@@ -65,6 +65,8 @@ fn to_toggle_case(str1: &Vec<char>) -> (toggle_case: Vec<char>)
             toggle_case.len() == index,
             forall|i: int|
                 0 <= i < index ==> toggle_case[i] == to_toggle_case_spec(#[trigger] str1[i]),
+        decreases
+            str1.len() - index,
     {
         if (str1[index] >= 'a' && str1[index] <= 'z') {
             toggle_case.push(((str1[index] as u8) - 32) as char);

--- a/benchmarks/MBPP/verified/task_id_567.rs
+++ b/benchmarks/MBPP/verified/task_id_567.rs
@@ -21,6 +21,8 @@ fn is_sorted(arr: &Vec<i32>) -> (is_sorted: bool)
         invariant
             0 <= index <= arr.len() - 1,
             forall|k: int, l: int| 0 <= k < l <= index ==> arr[k] <= arr[l],
+        decreases
+            arr.len() - 1 - index,
     {
         if arr[index] > arr[index + 1] {
             return false;

--- a/benchmarks/MBPP/verified/task_id_572.rs
+++ b/benchmarks/MBPP/verified/task_id_572.rs
@@ -35,6 +35,8 @@ fn count_frequency(arr: &Vec<i32>, key: i32) -> (frequency: usize)
             0 <= index <= arr.len(),
             0 <= counter <= index,
             count_frequency_rcr(arr@.subrange(0, index as int), key) == counter,
+        decreases
+            arr.len() - index,
     {
         if (arr[index] == key) {
             counter += 1;
@@ -64,6 +66,8 @@ fn remove_duplicates(arr: &Vec<i32>) -> (unique_arr: Vec<i32>)
             unique_arr@ == arr@.take(index as int).filter(
                 |x: i32| count_frequency_rcr(arr@, x) == 1,
             ),
+        decreases
+            arr.len() - index,
     {
         if count_frequency(&arr, arr[index]) == 1 {
             unique_arr.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_576.rs
+++ b/benchmarks/MBPP/verified/task_id_576.rs
@@ -37,6 +37,8 @@ fn sub_array_at_index(main: &Vec<i32>, sub: &Vec<i32>, idx: usize) -> (result: b
             forall|k: int| 0 <= k < i ==> main[idx + k] == sub[k],
             forall|k: int|
                 0 <= k < i ==> (main@.subrange(idx as int, (idx + k)) =~= sub@.subrange(0, k)),
+        decreases
+            sub.len() - i,
     {
         if (main[idx + i] != sub[i]) {
             assert(exists|k: int| 0 <= k < i ==> main[idx + k] != sub[k]);
@@ -71,6 +73,8 @@ fn is_sub_array(main: &Vec<i32>, sub: &Vec<i32>) -> (result: bool)
             forall|k: int, l: int|
                 (0 <= k < index) && l == k + sub.len() ==> (#[trigger] (main@.subrange(k, l))
                     != sub@),
+        decreases
+            (main.len() - sub.len()) + 1 - index,
     {
         if (sub_array_at_index(&main, &sub, index)) {
             return true;

--- a/benchmarks/MBPP/verified/task_id_576_v2.rs
+++ b/benchmarks/MBPP/verified/task_id_576_v2.rs
@@ -35,6 +35,8 @@ fn sub_array_at_index(main: &Vec<i32>, sub: &Vec<i32>, idx: usize) -> (result: b
             0 <= idx <= (main.len() - sub.len()),
             0 <= i <= sub.len(),
             forall|k: int| 0 <= k < i ==> main[idx + k] == sub[k],
+        decreases
+            sub.len() - i,
     {
         if (main[idx + i] != sub[i]) {
             return false;
@@ -63,6 +65,8 @@ fn is_sub_array(main: &Vec<i32>, sub: &Vec<i32>) -> (result: bool)
             sub.len() <= main.len(),
             0 <= index <= (main.len() - sub.len()) + 1,
             forall |k:int| 0<= k < index ==> !is_subrange_at(main@, sub@, k),
+        decreases
+            (main.len() - sub.len()) + 1 - index,
     {
         if (sub_array_at_index(&main, &sub, index)) {
             assert(is_subrange_at(main@, sub@, index as int));

--- a/benchmarks/MBPP/verified/task_id_578.rs
+++ b/benchmarks/MBPP/verified/task_id_578.rs
@@ -45,6 +45,8 @@ fn interleave(s1: &Vec<i32>, s2: &Vec<i32>, s3: &Vec<i32>) -> (res: Vec<i32>)
             forall|k: int|
                 0 <= k < index ==> (output_seq[3 * k] == s1[k] && output_seq[3 * k + 1] == s2[k]
                     && output_seq[3 * k + 2] == s3[k]),
+        decreases
+            s1.len() - index,
     {
         output_seq.push(s1[index]);
         output_seq.push(s2[index]);

--- a/benchmarks/MBPP/verified/task_id_579.rs
+++ b/benchmarks/MBPP/verified/task_id_579.rs
@@ -36,6 +36,8 @@ fn contains(arr: &Vec<i32>, key: i32) -> (result: bool)
     while index < arr.len()
         invariant
             forall|m: int| 0 <= m < index ==> (arr[m] != key),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] == key) {
             return true;
@@ -70,6 +72,8 @@ fn find_dissimilar(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 )),
             forall|m: int, n: int|
                 0 <= m < n < result.len() ==> #[trigger] result[m] != #[trigger] result[n],
+        decreases
+            arr1.len() - index,
     {
         if (!contains(arr2, arr1[index]) && !contains(&result, arr1[index])) {
             proof {
@@ -94,6 +98,8 @@ fn find_dissimilar(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 )),
             forall|m: int, n: int|
                 0 <= m < n < result.len() ==> #[trigger] result[m] != #[trigger] result[n],
+        decreases
+            arr2.len() - index,
     {
         if (!contains(arr1, arr2[index]) && !contains(&result, arr2[index])) {
             proof {

--- a/benchmarks/MBPP/verified/task_id_586.rs
+++ b/benchmarks/MBPP/verified/task_id_586.rs
@@ -28,6 +28,8 @@ fn split_and_append(list: &Vec<i32>, n: usize) -> (new_list: Vec<i32>)
         invariant
             n <= index <= list.len(),
             list@.subrange(n as int, index as int) =~= new_list@,
+        decreases
+            list.len() - index,
     {
         new_list.push(list[index]);
         index += 1;
@@ -40,6 +42,8 @@ fn split_and_append(list: &Vec<i32>, n: usize) -> (new_list: Vec<i32>)
             new_list@ =~= list@.subrange(n as int, list@.len() as int).add(
                 list@.subrange(0, index as int),
             ),
+        decreases
+            n - index,
     {
         new_list.push(list[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_588.rs
+++ b/benchmarks/MBPP/verified/task_id_588.rs
@@ -50,6 +50,8 @@ fn difference_max_min(arr: &Vec<i32>) -> (diff: i32)
             i32::MIN / 2 < max_val < i32::MAX / 2,
             max_val == max_rcur(arr@.subrange(0, index as int)),
             min_val == min_rcur(arr@.subrange(0, index as int)),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] <= min_val) {
             min_val = arr[index];

--- a/benchmarks/MBPP/verified/task_id_602.rs
+++ b/benchmarks/MBPP/verified/task_id_602.rs
@@ -41,6 +41,8 @@ fn count_frequency(arr: &Vec<char>, key: char) -> (frequency: usize)
             0 <= index <= arr.len(),
             0 <= counter <= index,
             count_frequency_rcr(arr@.subrange(0, index as int), key) == counter,
+        decreases
+            arr.len() - index,
     {
         if (arr[index] == key) {
             counter += 1;
@@ -75,6 +77,8 @@ fn first_repeated_char(str1: &Vec<char>) -> (repeated_char: Option<(usize, char)
             str1@.take(index as int) =~= str1@.take(index as int).filter(
                 |x: char| count_frequency_rcr(str1@, x) <= 1,
             ),
+        decreases
+            str1.len() - index,
     {
         if count_frequency(&str1, str1[index]) > 1 {
             return Some((index, str1[index]));

--- a/benchmarks/MBPP/verified/task_id_605.rs
+++ b/benchmarks/MBPP/verified/task_id_605.rs
@@ -33,6 +33,8 @@ fn prime_num(n: u64) -> (result: bool)
         invariant
             2 <= index <= n,
             forall|k: int| 2 <= k < index ==> !is_divisible(n as int, k),
+        decreases
+            n - index,
     {
         if ((n % index) == 0) {
             assert(is_divisible(n as int, index as int));

--- a/benchmarks/MBPP/verified/task_id_610.rs
+++ b/benchmarks/MBPP/verified/task_id_610.rs
@@ -34,6 +34,8 @@ fn remove_kth_element(list: &Vec<i32>, k: usize) -> (new_list: Vec<i32>)
             0 <= index <= k - 1,
             0 < k < list@.len(),
             new_list@ =~= list@.subrange(0, index as int),
+        decreases
+            k - 1 - index,
     {
         new_list.push(list[index]);
         index += 1;
@@ -45,6 +47,8 @@ fn remove_kth_element(list: &Vec<i32>, k: usize) -> (new_list: Vec<i32>)
             new_list@ =~= list@.subrange(0 as int, k - 1 as int).add(
                 list@.subrange(k as int, index as int),
             ),
+        decreases
+            list.len() - index,
     {
         new_list.push(list[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_616.rs
+++ b/benchmarks/MBPP/verified/task_id_616.rs
@@ -42,6 +42,8 @@ fn element_wise_module(arr1: &Vec<u32>, arr2: &Vec<u32>) -> (result: Vec<u32>)
                 (0 <= i < arr1.len()) ==> (i32::MIN <= #[trigger] (arr1[i] % arr2[i]) <= i32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] % arr2[k]),
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] % arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_618.rs
+++ b/benchmarks/MBPP/verified/task_id_618.rs
@@ -37,6 +37,8 @@ fn element_wise_divide(arr1: &Vec<u32>, arr2: &Vec<u32>) -> (result: Vec<u32>)
                 (0 <= i < arr1.len()) ==> (i32::MIN <= #[trigger] (arr1[i] / arr2[i]) <= i32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] / arr2[k]),
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] / arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_62.rs
+++ b/benchmarks/MBPP/verified/task_id_62.rs
@@ -25,6 +25,8 @@ fn smallest_num(nums: &Vec<i32>) -> (min: i32)
             0 <= index <= nums.len(),
             forall|k: int| 0 <= k < index ==> min <= nums[k],
             exists|k: int| 0 <= k < index && min == nums[k],
+        decreases
+            nums.len() - index,
     {
         if nums[index] < min {
             min = nums[index];

--- a/benchmarks/MBPP/verified/task_id_624.rs
+++ b/benchmarks/MBPP/verified/task_id_624.rs
@@ -55,6 +55,8 @@ fn to_uppercase(str1: &Vec<char>) -> (result: Vec<char>)
                 } else {
                     str1[i]
                 })),
+        decreases
+            str1.len() - index,
     {
         if (str1[index] >= 'a' && str1[index] <= 'z') {
             upper_case.push(((str1[index] as u8) - 32) as char);

--- a/benchmarks/MBPP/verified/task_id_629.rs
+++ b/benchmarks/MBPP/verified/task_id_629.rs
@@ -23,6 +23,8 @@ fn find_even_numbers(arr: &Vec<u32>) -> (even_numbers: Vec<u32>)
         invariant
             0 <= index <= arr.len(),
             even_numbers@ == arr@.take(index as int).filter(|x: u32| x % 2 == 0),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] % 2 == 0) {
             even_numbers.push(arr[index]);

--- a/benchmarks/MBPP/verified/task_id_644.rs
+++ b/benchmarks/MBPP/verified/task_id_644.rs
@@ -26,6 +26,8 @@ fn reverse_to_k(list: &Vec<i32>, n: usize) -> (reversed_list: Vec<i32>)
             0 <= index <= n,
             reversed_list.len() == index,
             forall|k: int| 0 <= k < index ==> reversed_list[k] == list[n - 1 - k],
+        decreases
+            n - index,
     {
         reversed_list.push(list[n - 1 - index]);
         index += 1;
@@ -37,6 +39,8 @@ fn reverse_to_k(list: &Vec<i32>, n: usize) -> (reversed_list: Vec<i32>)
             reversed_list@ =~= list@.subrange(0, n as int).reverse().add(
                 list@.subrange(n as int, index as int),
             ),
+        decreases
+            list.len() - index,
     {
         reversed_list.push(list[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_69.rs
+++ b/benchmarks/MBPP/verified/task_id_69.rs
@@ -26,6 +26,8 @@ fn is_sub_list_at_index(main: &Vec<i32>, sub: &Vec<i32>, idx: usize) -> (result:
             forall|k: int| 0 <= k < i ==> main[idx + k] == sub[k],
             forall|k: int|
                 0 <= k < i ==> (main@.subrange(idx as int, (idx + k)) =~= sub@.subrange(0, k)),
+        decreases
+            sub.len() - i,
     {
         if (main[idx + i] != sub[i]) {
             assert(exists|k: int| 0 <= k < i ==> main[idx + k] != sub[k]);
@@ -59,6 +61,8 @@ fn is_sub_list(main: &Vec<i32>, sub: &Vec<i32>) -> (result: bool)
             forall|k: int, l: int|
                 (0 <= k < index) && l == k + sub.len() ==> (#[trigger] (main@.subrange(k, l))
                     != sub@),
+        decreases
+            (main.len() - sub.len()) + 1 - index,
     {
         if (is_sub_list_at_index(&main, &sub, index)) {
             return true;

--- a/benchmarks/MBPP/verified/task_id_70.rs
+++ b/benchmarks/MBPP/verified/task_id_70.rs
@@ -27,6 +27,8 @@ fn all_sequence_equal_length(seq: &Vec<Vec<i32>>) -> (result: bool)
         invariant
             1 <= index <= seq.len(),
             forall|k: int| 0 <= k < index ==> (#[trigger] seq[k].len() == (&seq[0]).len()),
+        decreases
+            seq.len() - index,
     {
         if ((&seq[index]).len() != (&seq[0]).len()) {
             return false;

--- a/benchmarks/MBPP/verified/task_id_728.rs
+++ b/benchmarks/MBPP/verified/task_id_728.rs
@@ -34,6 +34,8 @@ fn add_list(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 (0 <= i < arr1.len()) ==> (i32::MIN <= #[trigger] (arr1[i] + arr2[i]) <= i32::MAX),
             forall|k: int|
                 0 <= k < index ==> #[trigger] output_arr[k] == #[trigger] (arr1[k] + arr2[k]),
+        decreases
+            arr1.len() - index,
     {
         output_arr.push((arr1[index] + arr2[index]));
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_732.rs
+++ b/benchmarks/MBPP/verified/task_id_732.rs
@@ -51,6 +51,8 @@ fn replace_with_colon(str1: &Vec<char>) -> (result: Vec<char>)
                 } else {
                     str1[k]
                 }),
+        decreases
+            str1.len() - index,
     {
         if ((str1[index] == ' ') || (str1[index] == ',') || (str1[index] == '.')) {
             result.push(':');

--- a/benchmarks/MBPP/verified/task_id_733.rs
+++ b/benchmarks/MBPP/verified/task_id_733.rs
@@ -39,6 +39,8 @@ fn find_first_occurrence(arr: &Vec<i32>, target: i32) -> (index: Option<usize>)
     while index < arr.len()
         invariant
             forall|k: int| 0 <= k < index ==> arr[k] != target,
+        decreases
+            arr.len() - index,
     {
         if arr[index] == target {
             return Some(index);

--- a/benchmarks/MBPP/verified/task_id_741.rs
+++ b/benchmarks/MBPP/verified/task_id_741.rs
@@ -23,6 +23,8 @@ fn all_characters_same(char_arr: &Vec<char>) -> (result: bool)
         invariant
             1 <= index <= char_arr.len(),
             forall|k: int| 0 <= k < index ==> char_arr[0] == #[trigger] char_arr[k],
+        decreases
+            char_arr.len() - index,
     {
         if char_arr[0] != char_arr[index] {
             assert(exists|i: int|

--- a/benchmarks/MBPP/verified/task_id_743.rs
+++ b/benchmarks/MBPP/verified/task_id_743.rs
@@ -42,6 +42,8 @@ fn rotate_right(list: &Vec<u32>, n: usize) -> (new_list: Vec<u32>)
         invariant
             split_index <= index <= list.len(),
             list@.subrange(split_index as int, index as int) =~= new_list@,
+        decreases
+            list.len() - index,
     {
         new_list.push(list[index]);
         index += 1;
@@ -54,6 +56,8 @@ fn rotate_right(list: &Vec<u32>, n: usize) -> (new_list: Vec<u32>)
             new_list@ =~= list@.subrange(split_index as int, list@.len() as int).add(
                 list@.subrange(0, index as int),
             ),
+        decreases
+            split_index - index,
     {
         new_list.push(list[index]);
         index += 1;

--- a/benchmarks/MBPP/verified/task_id_755.rs
+++ b/benchmarks/MBPP/verified/task_id_755.rs
@@ -64,6 +64,8 @@ fn second_smallest(numbers: &Vec<i32>) -> (indices: (
             forall|k: int| 0 <= k < index ==> numbers[k] >= numbers[min_index as int],
             forall|k: int|
                 0 <= k < index && k != min_index ==> numbers[k] >= numbers[second_min_index as int],
+        decreases
+            numbers.len() - index,
     {
         if numbers[index] < numbers[min_index] {
             second_min_index = min_index;

--- a/benchmarks/MBPP/verified/task_id_760.rs
+++ b/benchmarks/MBPP/verified/task_id_760.rs
@@ -22,6 +22,8 @@ fn has_only_one_distinct_element(arr: &Vec<i32>) -> (result: bool)
         invariant
             1 <= index <= arr.len(),
             forall|k: int| 0 <= k < index ==> arr[0] == #[trigger] arr[k],
+        decreases   
+            arr.len() - index,
     {
         if arr[0] != arr[index] {
             assert(exists|i: int| 1 <= i < arr@.len() && arr[0] != #[trigger] arr[i]);

--- a/benchmarks/MBPP/verified/task_id_764.rs
+++ b/benchmarks/MBPP/verified/task_id_764.rs
@@ -42,6 +42,8 @@ fn count_digits(text: &Vec<char>) -> (count: usize)
             0 <= index <= text.len(),
             0 <= count <= index,
             count == count_digits_recursively(text@.subrange(0, index as int)),
+        decreases
+            text.len() - index,
     {
         if ((text[index] as u8) >= 48 && (text[index] as u8) <= 57) {
             count += 1;

--- a/benchmarks/MBPP/verified/task_id_769.rs
+++ b/benchmarks/MBPP/verified/task_id_769.rs
@@ -33,6 +33,8 @@ fn contains(arr: &Vec<i32>, key: i32) -> (result: bool)
     while index < arr.len()
         invariant
             forall|m: int| 0 <= m < index ==> (arr[m] != key),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] == key) {
             return true;
@@ -67,6 +69,8 @@ fn difference(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 )),
             forall|m: int, n: int|
                 0 <= m < n < result.len() ==> #[trigger] result[m] != #[trigger] result[n],
+        decreases
+            arr1.len() - index,
     {
         if (!contains(arr2, arr1[index]) && !contains(&result, arr1[index])) {
             proof {
@@ -90,6 +94,8 @@ fn difference(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: Vec<i32>)
                 )),
             forall|m: int, n: int|
                 0 <= m < n < result.len() ==> #[trigger] result[m] != #[trigger] result[n],
+        decreases
+            arr2.len() - index,
     {
         if (!contains(arr1, arr2[index]) && !contains(&result, arr2[index])) {
             proof {

--- a/benchmarks/MBPP/verified/task_id_775.rs
+++ b/benchmarks/MBPP/verified/task_id_775.rs
@@ -19,6 +19,8 @@ fn is_odd_at_odd_index(arr: &Vec<usize>) -> (result: bool)
         invariant
             0 <= index <= arr.len(),
             forall|i: int| 0 <= i < index ==> ((i % 2) == (arr[i] % 2)),
+        decreases
+            arr.len() - index,
     {
         if ((index % 2) != (arr[index] % 2)) {
             assert(((index as int) % 2) != (arr[index as int] % 2));

--- a/benchmarks/MBPP/verified/task_id_790.rs
+++ b/benchmarks/MBPP/verified/task_id_790.rs
@@ -19,6 +19,8 @@ fn is_even_at_even_index(arr: &Vec<usize>) -> (result: bool)
         invariant
             0 <= index <= arr.len(),
             forall|i: int| 0 <= i < index ==> ((i % 2) == (arr[i] % 2)),
+        decreases
+            arr.len() - index,
     {
         if ((index % 2) != (arr[index] % 2)) {
             assert(((index as int) % 2) != (arr[index as int] % 2));

--- a/benchmarks/MBPP/verified/task_id_798.rs
+++ b/benchmarks/MBPP/verified/task_id_798.rs
@@ -34,6 +34,8 @@ fn sum(arr: &Vec<i64>) -> (sum: i128)
             forall|j: int|
                 0 <= j <= index ==> (i64::MIN * index <= (sum_to(#[trigger] arr@.subrange(0, j)))
                     <= i64::MAX * index),
+        decreases
+            arr.len() - index,
     {
         assert(arr@.subrange(0, index as int) =~= arr@.subrange(0, (index + 1) as int).drop_last());
         sum = sum + arr[index] as i128;

--- a/benchmarks/MBPP/verified/task_id_8.rs
+++ b/benchmarks/MBPP/verified/task_id_8.rs
@@ -31,6 +31,8 @@ fn square_nums(nums: &Vec<i32>) -> (squared: Vec<i32>)
             forall|k: int|
                 0 <= k < nums.len() ==> (0 <= #[trigger] nums[k] * #[trigger] nums[k] < i32::MAX),
             forall|k: int| 0 <= k < index ==> (#[trigger] result[k] == nums[k] * nums[k]),
+        decreases
+            nums.len() - index,
     {
         result.push(nums[index] * nums[index]);
         index += 1

--- a/benchmarks/MBPP/verified/task_id_804.rs
+++ b/benchmarks/MBPP/verified/task_id_804.rs
@@ -21,6 +21,8 @@ fn is_product_even(arr: &Vec<u32>) -> (result: bool)
         invariant
             0 <= index <= arr.len(),
             forall|k: int| 0 <= k < index ==> !(is_even(#[trigger] arr[k])),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] % 2 == 0) {
             return true;

--- a/benchmarks/MBPP/verified/task_id_807.rs
+++ b/benchmarks/MBPP/verified/task_id_807.rs
@@ -27,6 +27,8 @@ fn find_first_odd(arr: &Vec<u32>) -> (index: Option<usize>)
         invariant
             0 <= index <= arr.len(),
             arr@.take(index as int) =~= arr@.take(index as int).filter(|x: u32| x % 2 == 0),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] % 2 != 0) {
             return Some(index);

--- a/benchmarks/MBPP/verified/task_id_808.rs
+++ b/benchmarks/MBPP/verified/task_id_808.rs
@@ -19,6 +19,8 @@ fn contains_k(arr: &Vec<i32>, k: i32) -> (result: bool)
         invariant
             0 <= index <= arr.len(),
             forall|m: int| 0 <= m < index ==> (arr[m] != k),
+        decreases
+            arr.len() - index,
     {
         if (arr[index] == k) {
             return true;

--- a/benchmarks/MBPP/verified/task_id_809.rs
+++ b/benchmarks/MBPP/verified/task_id_809.rs
@@ -23,6 +23,8 @@ fn is_smaller(arr1: &Vec<i32>, arr2: &Vec<i32>) -> (result: bool)
             arr1.len() == arr2.len(),
             0 <= index <= arr2.len(),
             forall|k: int| 0 <= k < index ==> arr1[k] > arr2[k],
+        decreases
+            arr1.len() - index,
     {
         if arr1[index] <= arr2[index] {
             return false;

--- a/benchmarks/MBPP/verified/task_id_94.rs
+++ b/benchmarks/MBPP/verified/task_id_94.rs
@@ -37,6 +37,8 @@ fn min_second_value_first(arr: &Vec<Vec<i32>>) -> (first_of_min_second: i32)
             forall|i: int| 0 <= i < arr.len() ==> #[trigger] arr[i].len() >= 2,
             forall|k: int|
                 0 <= k < index ==> (arr[min_second_index as int][1] <= #[trigger] arr[k][1]),
+        decreases
+            arr.len() - index,
     {
         assert(arr[index as int].len() > 0);
         assert(arr[min_second_index as int].len() > 0);

--- a/benchmarks/MBPP/verified/task_id_95.rs
+++ b/benchmarks/MBPP/verified/task_id_95.rs
@@ -32,6 +32,8 @@ fn smallest_list_length(list: &Vec<Vec<i32>>) -> (min: usize)
             0 <= index <= list.len(),
             forall|k: int| 0 <= k < index ==> min <= #[trigger] list[k].len(),
             exists|k: int| 0 <= k < index && min == #[trigger] list[k].len(),
+        decreases
+            list.len() - index,
     {
         if (&list[index]).len() < min {
             min = (&list[index]).len();

--- a/benchmarks/Misc/verified/arg_free.rs
+++ b/benchmarks/Misc/verified/arg_free.rs
@@ -14,6 +14,8 @@ fn choose_odd()
         idx<=10,
         gap<100,
         gap==res-idx,
+    decreases
+        10-idx,
     {
         res = res + 1;
         idx = idx + 1;
@@ -27,6 +29,9 @@ fn choose_odd()
         idx<=10,
         gap<100,
         gap==res-idx,
+    decreases
+        10-idx,
+    
     {
         
         res = res + 1;

--- a/benchmarks/Misc/verified/binary_search.rs
+++ b/benchmarks/Misc/verified/binary_search.rs
@@ -18,6 +18,8 @@ fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
             i2 < v.len(),
             exists|i: int| i1 <= i <= i2 && k == v[i],
             forall|i: int, j: int| 0 <= i <= j < v.len() ==> v[i] <= v[j],
+        decreases
+            i2 - i1,
     {
         let ix = i1 + (i2 - i1) / 2;
         if v[ix] < k {

--- a/benchmarks/Misc/verified/bubble_v1.rs
+++ b/benchmarks/Misc/verified/bubble_v1.rs
@@ -38,6 +38,8 @@ verus! {
                     forall|x: int, y: int| 0 <= x <= y <= i ==> x != j && y != j ==> nums[x] <= nums[y],
                     sorted_between(nums@, j as int, i + 1),
                     is_reorder_of(r, nums@, old(nums)@),
+                decreases
+                    j,
             {
                 if nums[j - 1] > nums[j] {
                     let temp = nums[j - 1];

--- a/benchmarks/Misc/verified/bubble_v2.rs
+++ b/benchmarks/Misc/verified/bubble_v2.rs
@@ -41,6 +41,8 @@ verus! {
                     forall|x: int, y: int| 0 <= x <= y <= i ==> x != j && y != j ==> nums[x] <= nums[y],
                     sorted_between(nums@, j as int, i + 1),
                     exists|r: Seq<int>| is_reorder_of(r, nums@, old(nums)@),
+                decreases
+                    j,
             {
                 if nums[j - 1] > nums[j] {
                     proof {

--- a/benchmarks/Misc/verified/cell_2_sum.rs
+++ b/benchmarks/Misc/verified/cell_2_sum.rs
@@ -14,6 +14,8 @@ pub fn myfun(a: &mut Vec<u32>, N: u32) -> (sum: u32)
 	invariant 
 	    a.len()==N,
 	    forall|j:int| 0<=j<i ==> a[j]<=2,
+	decreases
+	    N - i,
 	{
 		if (a[i] > 2) {
 			a.set(i, 2);
@@ -32,6 +34,9 @@ pub fn myfun(a: &mut Vec<u32>, N: u32) -> (sum: u32)
 	    a.len()==N,
 	    forall|j:int| 0<=j<N ==> a[j]<=2,
 	    sum<=2 * i,
+	decreases
+	    N - i,
+	
 	{
         sum = sum + a[i];
 		i = i + 1;

--- a/benchmarks/Misc/verified/choose_odd.rs
+++ b/benchmarks/Misc/verified/choose_odd.rs
@@ -13,6 +13,8 @@ fn choose_odd(v: &Vec<u64>) -> (odd_index: usize)
     while (j < v.len())
     invariant 
         forall |q:int| 0<=q<j ==> #[trigger] v[q]%2!=1,
+    decreases
+        v.len() - j,
     {
         if (v[j] % 2 == 1) {
             return j;

--- a/benchmarks/Misc/verified/conditional_average.rs
+++ b/benchmarks/Misc/verified/conditional_average.rs
@@ -36,6 +36,8 @@ fn conditional_average(vals_1: &Vec<u64>, vals_2: &Vec<u64>, conds_1: &Vec<bool>
             (conds_1[i] && !conds_2[i] ==> avgs[i] == vals_1[i]) &&
             (!conds_1[i] && conds_2[i] ==> avgs[i] == vals_2[i])
         ),
+    decreases
+        common_len - k,
     {
         let mut new_avg: u64 = 0;
         if (conds_1[k]) {

--- a/benchmarks/Misc/verified/deduplicate.rs
+++ b/benchmarks/Misc/verified/deduplicate.rs
@@ -71,6 +71,8 @@ ensures
         0 <= i <= nums@.len(),
         nums@.subrange(0, i  as int).to_set().ext_equal(res@.to_set()),
         res@.no_duplicates(),
+    decreases
+        nums.len() - i,
     {
         let mut found = false;
         let mut j = 0;

--- a/benchmarks/Misc/verified/fib.rs
+++ b/benchmarks/Misc/verified/fib.rs
@@ -50,6 +50,8 @@ ensures
             2 <= i,
             fib@.len() == i, 
             i <= n,
+        decreases
+            n - i,
     {
         proof{
             fibo_is_monotonic(i as int, n as int);

--- a/benchmarks/Misc/verified/filter.rs
+++ b/benchmarks/Misc/verified/filter.rs
@@ -17,6 +17,8 @@ ensures
             0 <= i <= xlen,
             x@.len() == xlen,  // always specify the length of vectors used in the loop
             y@ == x@.take(i as int).filter(|k:u64| k%3 == 0),//routine for filter
+        decreases
+            xlen - i,
     { 
         if (x[i] % 3 == 0) {
             y.push(x[i]);

--- a/benchmarks/Misc/verified/filter_v2.rs
+++ b/benchmarks/Misc/verified/filter_v2.rs
@@ -34,6 +34,8 @@ ensures
             0 <= i <= xlen,
             x@.len() == xlen,  
             y@ == x@.take(i as int).filter(|k:u64| k%3 == 0),
+        decreases
+            xlen - i,
     { 
         if (x[i] % 3 == 0) {
             y.push(x[i]);

--- a/benchmarks/Misc/verified/filter_weak.rs
+++ b/benchmarks/Misc/verified/filter_weak.rs
@@ -17,6 +17,8 @@ ensures
         invariant 
             x@.len() == xlen,  // always specify the length of vectors used in the loop
             forall |k:int| 0 <= k < y.len() ==> y[k] % 3 == 0 && x@.contains(y@[k]),
+        decreases
+            xlen - i,
     { 
         if (x[i] % 3 == 0) {
             y.push(x[i]);

--- a/benchmarks/Misc/verified/findmax.rs
+++ b/benchmarks/Misc/verified/findmax.rs
@@ -16,6 +16,8 @@ ensures
     invariant
         forall |k: int| 0 <= k < i ==> nums@[k] <= max,
         exists |k: int| 0 <= k < i && nums@[k] == max,
+    decreases
+        nums.len() - i,
     {
         if nums[i] > max {
             max = nums[i];

--- a/benchmarks/Misc/verified/havoc_inline_post.rs
+++ b/benchmarks/Misc/verified/havoc_inline_post.rs
@@ -19,6 +19,8 @@ pub fn havoc_inline_post(v: &mut Vec<u32>, a: u32, b: bool)
             forall |k:int| idx <= k < v.len() ==> v[k] == 1 + a,
             forall |k:int| 0 <= k < idx ==> v[k] == 1,
             10 < a < 20,
+        decreases
+            idx,
     {
         idx = idx - 1;
         v.set(idx, v[idx] + a);

--- a/benchmarks/Misc/verified/linearsearch.rs
+++ b/benchmarks/Misc/verified/linearsearch.rs
@@ -20,6 +20,8 @@ ensures
         0 <= i <= nums@.len(),
     ensures
         0 <= i < nums@.len() ==> (#[trigger]nums@[i as int]) == target,
+    decreases
+        nums.len() - i,
     {
         if nums[i] == target {
             break;

--- a/benchmarks/Misc/verified/map.rs
+++ b/benchmarks/Misc/verified/map.rs
@@ -16,6 +16,8 @@ ensures
             forall |k:int| 0 <= k < i ==> #[trigger] x[k] == old(x)[k] + 4,
             forall |k:int| i <= k < xlen ==> x[k] == old(x)[k],
             forall |k:int| 0 <= k < xlen ==> old(x)[k] <= 0x7FFF_FFFB,
+        decreases
+            xlen - i,
     { 
         x.set(i, x[i] + 4);  
         i = i + 1;

--- a/benchmarks/Misc/verified/max_index.rs
+++ b/benchmarks/Misc/verified/max_index.rs
@@ -16,6 +16,8 @@ pub fn myfun1(x: &Vec<i32>) -> (max_index: usize)
             i <= x.len(),
             max_index < x.len(),
             forall|k: int| 0 <= k < i ==> x[max_index as int] >= x[k],
+        decreases
+            x.len() - i,
     {
         if x[i] > x[max_index] {
             max_index = i;

--- a/benchmarks/Misc/verified/remove_all_greater.rs
+++ b/benchmarks/Misc/verified/remove_all_greater.rs
@@ -15,6 +15,8 @@ pub fn remove_all_greater(v: Vec<i32>, e: i32) -> (result: Vec<i32>)
         invariant 
             forall |k:int| 0 <= k < result.len() ==> result[k] <= e && v@.contains(result[k]),
             forall |k:int| 0 <= k < i && v[k] <= e ==> result@.contains(v[k]),
+        decreases
+            vlen - i,
     {  
         if (v[i] <= e) {
             let ghost old_result = result;

--- a/benchmarks/Misc/verified/remove_all_greater_v2.rs
+++ b/benchmarks/Misc/verified/remove_all_greater_v2.rs
@@ -25,6 +25,8 @@ pub fn remove_all_greater(v: Vec<i32>, e: i32) -> (result: Vec<i32>)
         invariant
             forall |k:int| 0 <= k < result.len() ==> result[k] <= e && v@.contains(result[k]),
             forall |k:int| 0 <= k < i && v[k] <= e ==> result@.contains(v[k]),
+        decreases
+            v.len() - i,
     {  
         if (v[i] <= e) { 
             proof{

--- a/benchmarks/Misc/verified/simple_nested.rs
+++ b/benchmarks/Misc/verified/simple_nested.rs
@@ -20,6 +20,8 @@ pub fn simple_nested(a: &mut Vec<i32>, b: &Vec<i32>, N: i32) -> (sum: i32)
             b.len() == N,  // always specify the length of vectors used in the loop
             forall |k:int| k <= #[trigger] b[k] <= k + 1,
             i <= sum <= 2*i,
+        decreases
+            N - i,
     {  
         a.set(i, b[i] + 1);
         let mut j: usize = 0;

--- a/benchmarks/Misc/verified/sum.rs
+++ b/benchmarks/Misc/verified/sum.rs
@@ -36,6 +36,8 @@ fn compute_arith_sum(n: u64) -> (sum: u64)
             i <= n,
             sum == arith_sum_int(i as nat),
             arith_sum_int(n as nat) < 10000,
+        decreases
+            n - i,
     {
         i = i + 1;
 

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/brs1.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/brs1.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
         invariant
             a.len() == N,
             forall |k:int| 0 <= k < i ==> a[k] == 1,
+        decreases
+            N - i,
     {
         if (i % 1 == 0) {
             a.set(i, 1);
@@ -33,6 +35,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
             a.len() == N,
             i > 0 ==> sum[0] <= i,
             forall |k:int| 0 <= k < N ==> a[k] == 1,
+        decreases
+            N - i,
     {
         if (i == 0) {
             sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/brs2.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/brs2.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 2 || a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (i % 2 == 0) {
 			a.set(i, 2);
@@ -35,6 +37,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			i > 0 ==> sum[0] <= 2 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/brs3.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/brs3.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k: int| 0<= k < i ==> a[k] == 3 || a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (i % 3 == 0) {
 			a.set(i, 3);
@@ -35,6 +37,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			i>0 ==> sum[0] <= 3 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/brs4.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/brs4.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 4 || a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (i % 4 == 0) {
 			a.set(i, 4);
@@ -35,6 +37,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			i > 0 ==> sum[0] <= 4 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/brs5.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/brs5.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 5 || a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (i % 5 == 0) {
 			a.set(i, 5);
@@ -35,6 +37,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			i>0 ==> sum[0] <= 5 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/conda.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/conda.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0<= k < i ==> a[k] == 2,
 			forall |k:int| i<= k < N ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 1);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			a.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/condg.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/condg.rs
@@ -15,6 +15,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant 
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum[0] == i,
 			sum.len() == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -41,6 +45,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum.len() == 1,
 			sum[0] == N,
+		decreases
+			N - i,
 	{
 		if (sum[0] == N) {
 			a.set(i, a[i] - 1);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/condm.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/condm.rs
@@ -14,6 +14,8 @@ pub fn myfun(a: &mut Vec<i32>, N: u32)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 0);
 		i = i + 1;
@@ -25,6 +27,8 @@ pub fn myfun(a: &mut Vec<i32>, N: u32)
 			forall |k:int| 0 <= k < i ==> a[k] % 2 == N % 2,
 			forall |k:int| i <= k < N ==> a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (N % 2 == 0) {
 			a.set(i, a[i] + 2);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/condn.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/condn.rs
@@ -13,6 +13,8 @@ pub fn myfun(a: &mut Vec<i32>, N: i32, m: i32)
 	while (i < N as usize)
 		invariant
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, m);
 		i = i + 1;
@@ -23,6 +25,8 @@ pub fn myfun(a: &mut Vec<i32>, N: i32, m: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] <= N,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] < N) {
 			a.set(i, a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/ms1.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/ms1.rs
@@ -15,6 +15,8 @@ pub fn myfun(a: &mut Vec<usize>, sum: &mut Vec<usize>, N: usize)
 		invariant
 			forall |k: int| 0<= k < i ==> a[k] == 0,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, i % 1 );
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<usize>, sum: &mut Vec<usize>, N: usize)
 			a.len() == N,
 			i > 0 ==> sum[0] == 0,
 			sum.len() == 1,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/ms2.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/ms2.rs
@@ -15,6 +15,8 @@ pub fn myfun(a: &mut Vec<usize>, sum: &mut Vec<usize>, N: usize)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 0 || a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, i % 2 );
 		i = i + 1;
@@ -29,6 +31,8 @@ pub fn myfun(a: &mut Vec<usize>, sum: &mut Vec<usize>, N: usize)
 			a.len() == N,
 			sum.len() == 1,
 			i>0 ==> sum[0] <= i,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/ms3.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/ms3.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 0 || a[k] == 1 || a[k] == 2,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, (i % 3) as i32);
 		i = i + 1;
@@ -31,6 +33,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			i > 0 ==> sum[0] <= 2 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/ms4.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/ms4.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == k % 4,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, (i % 4) as i32);
 		i = i + 1;
@@ -31,6 +33,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0<= k < N ==> a[k] == k % 4,
 			a.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/ms5.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/ms5.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == k % 5,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, (i % 5) as i32);
 		i = i + 1;
@@ -31,6 +33,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			i > 0 ==> sum[0] <= 4 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (i == 0) {
 			sum.set(0, 0);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/res1.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/res1.rs
@@ -20,6 +20,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			a.len() == N,
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -30,6 +32,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			b.len() == N,
 			forall |k:int| 0 <= k < i ==> b[k] == 1,
+		decreases
+			N - i,
 	{
 		b.set(i, 1);
 		i = i + 1;
@@ -43,6 +47,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == i,
             a.len() == N,
 			forall |k:int| 0 <= k < N ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -57,6 +63,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == N + i,
             N < 1000,
 			forall |k:int| 0 <= k < N ==> b[k] == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + b[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/res1o.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/res1o.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			a.len() == N,
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -30,6 +32,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum[0] == i, // Corrected invariant
 			forall |k:int| 0 <= k < N ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -40,6 +44,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			b.len() == N,
 			forall |k:int| 0 <= k < i ==> b[k] == 1,
+		decreases
+			N - i,
 	{
 		b.set(i, 1);
 		i = i + 1;
@@ -54,6 +60,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == N + i,
 			forall |k:int| 0 <= k < N ==> b[k] == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + b[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/res2.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/res2.rs
@@ -20,6 +20,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 		invariant
 			a.len() == N,
 			forall |j: int| 0<= j < i ==> a[j] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -33,6 +35,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 			sum[0] == i,
 			a.len() == N,
 			forall |j: int| 0 <= j < N ==> a[j] == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -43,6 +47,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 		invariant
 			b.len() == N,
 			forall |j: int| 0 <= j < i ==> b[j] == 1,
+		decreases
+			N - i,
 	{
 		b.set(i, 1);
 		i = i + 1;
@@ -57,6 +63,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 			b.len() == N,
 			forall |j: int| 0 <= j < N ==> b[j] == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + b[i]);
 		i = i + 1;
@@ -67,6 +75,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 		invariant
 			forall |j: int| 0<= j < i ==> c[j] == 1,
 			c.len() == N,
+		decreases
+			N - i,
 	{
 		c.set(i, 1);
 		i = i + 1;
@@ -81,6 +91,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 			forall |j: int| 0 <= j < N ==> c[j] == 1,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + c[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/res2o.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/res2o.rs
@@ -19,6 +19,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 		invariant
 			forall |j: int| 0<= j < i ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -29,6 +31,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 		invariant
 			forall |j: int| 0<= j < i ==> b[j] == 1,
 			b.len() == N,
+		decreases
+			N - i,
 	{
 		b.set(i, 1);
 		i = i + 1;
@@ -39,6 +43,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 		invariant
 			forall |j: int| 0<= j < i ==> c[j] == 1,
 			c.len() == N,
+		decreases
+			N - i,
 	{
 		c.set(i, 1);
 		i = i + 1;
@@ -52,6 +58,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 			sum[0] == i,
 			forall |j: int| 0<= j < N ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -66,6 +74,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 			forall |j: int| 0<= j < N ==> b[j] == 1,
 			b.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + b[i]);
 		i = i + 1;
@@ -80,6 +90,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, c: &mut Vec<i32>, sum: &mut Vec
 			forall |j: int| 0<= j < N ==> c[j] == 1,
 			c.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + c[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s12if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s12if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 		invariant
 			a.len() == N,
 			forall |k:int| 0<= k < i ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			a.len() == N,
 			forall |k:int| 0<= k < i ==> a[k] == 2,
 			forall |k:int| i<= k < N ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 1);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			sum.len() == 1,
 			sum[0] == 2 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 2) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s1if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s1if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -29,6 +31,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum[0] == i,
 			sum.len() == 1,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s1lif.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s1lif.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			a.len() == N,
 			forall |j: int| 0<= j < i ==> a[j] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			forall |j: int| 0<= j < i ==> a[j] == 2,
 			forall |j: int| i<= j < N ==> a[j] == 1,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 1);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			sum[0] == 2 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s22if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s22if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 		invariant
 			a.len() == N,
 			forall |k:int| 0<= k < i ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			a.len() == N,
 			forall |k:int| 0<= k < i ==> a[k] == 3,
 			forall |k:int| i<= k < N ==> a[k] == 1,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 2);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			sum.len() == 1,
 			sum[0] == 3 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 3) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s2if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s2if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 2,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 2);
 		i = i + 1;
@@ -30,6 +32,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == 2 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 2) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s2lif.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s2lif.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |j: int| 0<= j < i ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |j: int| 0<= j < i ==> a[j] == 3,
 			forall |j: int| i <= j < N ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 2);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == 3 * i,
 			N <= 1000,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s32if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s32if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 		invariant
 			forall |k:int| 0<=k <i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			forall |k:int| 0<=k <i ==> a[k] == 4,
 			forall |k:int| i<=k <N ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 3);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			sum[0] == 4 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 4) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s3if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s3if.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 3,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 3);
 		i = i + 1;
@@ -31,6 +33,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == 3 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 3) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s3lif.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s3lif.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |j: int| 0<= j < i ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |j: int| 0<= j < i ==> a[j] == 4,
 			forall |j: int| i <= j < N ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 3);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			sum[0] == 4 * i,
 			N <= 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s42if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s42if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			forall |k:int| 0<= k < i ==> a[k] == 5,
 			forall |k:int| i<= k < N ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 4);
@@ -45,6 +49,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			sum[0] == 5 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 5)
 		{

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s4if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s4if.rs
@@ -16,6 +16,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 4,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 4);
 		i = i + 1;
@@ -30,6 +32,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == 4 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 4) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s4lif.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s4lif.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			a.len() == N,
 			forall |j: int| 0<= j < i ==> a[j] == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			forall |j: int| 0<= j < i ==> a[j] == 5,
 			forall |j: int| i <= j < N ==> a[j] == 1,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 4);
@@ -46,6 +50,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |j: int| 0<= j < N ==> a[j] == 5,
 			sum[0] == 5 * i,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s52if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s52if.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			forall |k:int| 0 <= k < i ==> a[k] == 6,
 			forall |k:int| i <= k < N ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 5);
@@ -46,6 +50,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: usize)
 			sum[0] == 6 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 6)
 		{

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s5if.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s5if.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0<= k < i ==> a[k] == 5,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 5);
 		i = i + 1;
@@ -31,6 +33,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == 5 * i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		if (a[i] == 5) {
 			sum.set(0, sum[0] + a[i]);

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/s5lif.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/s5lif.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |j: int| 0<= j < i ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |j: int| 0<= j < i ==> a[j] == 6,
 			forall |j: int| i <= j < N ==> a[j] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		if (a[i] == 1) {
 			a.set(i, a[i] + 5);
@@ -46,6 +50,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			a.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/sina1.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/sina1.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			i <= N,
 			sum.len() == 1,
 			sum[0] == i,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + 1);
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0 <= k < i ==> a[k] == sum[0],
 			sum.len() == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, sum[0]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/sina2.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/sina2.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -30,6 +32,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == i,
 			a.len() == N,
 			sum.len() == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -44,6 +48,8 @@ pub fn myfun(a: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		a.set(i, a[i] + sum[0]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/sina3.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/sina3.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -27,6 +29,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> b[k] == 1,
 			b.len() == N,
+		decreases
+			N - i,
 	{
 		b.set(i, 1);
 		i = i + 1;
@@ -40,6 +44,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0 <= k < N ==> a[k] == 1,
 			a.len() == N,
 			sum[0] == i,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -55,6 +61,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum.len() == 1,
 			sum[0] == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		a.set(i, b[i] + sum[0]);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/sina4.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/sina4.rs
@@ -17,6 +17,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -30,6 +32,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum[0] == i,
 			sum.len() == 1,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -44,6 +48,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0 <= k < i ==> a[k] == N + 1,
 			a.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		a.set(i, a[i] + sum[0]);
 		i = i + 1;
@@ -57,6 +63,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0 <= k < i ==> b[k] == N + 2,
 			b.len() == N,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		b.set(i, a[i] + 1);
 		i = i + 1;

--- a/benchmarks/SVComp-Array-fpi-nonl/verified/sina5.rs
+++ b/benchmarks/SVComp-Array-fpi-nonl/verified/sina5.rs
@@ -18,6 +18,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> a[k] == 1,
 			a.len() == N,
+		decreases
+			N - i,
 	{
 		a.set(i, 1);
 		i = i + 1;
@@ -28,6 +30,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 		invariant
 			forall |k:int| 0 <= k < i ==> b[k] == 1,
 			b.len() == N,
+		decreases
+			N - i,
 	{
 		b.set(i, 1);
 		i = i + 1;
@@ -41,6 +45,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			forall |k:int| 0 <= k < N ==> a[k] == 1,
 			a.len() == N,
 			sum[0] == i,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + a[i]);
 		i = i + 1;
@@ -55,6 +61,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			sum[0] == N + i,
 			sum.len() == 1,
 			N < 1000,
+		decreases
+			N - i,
 	{
 		sum.set(0, sum[0] + b[i]);
 		i = i + 1;
@@ -68,6 +76,8 @@ pub fn myfun(a: &mut Vec<i32>, b: &mut Vec<i32>, sum: &mut Vec<i32>, N: i32)
 			a.len() == N,
 			sum[0] == 2 * N,
 			sum.len() == 1,
+		decreases
+			N - i,
 	{
 		a.set(i, a[i] + sum[0]);
 		i = i + 1;


### PR DESCRIPTION
This pull request adds `decreases` clauses for loops in verified source to satisfy the exec termination check introduced by [latest Verus](https://github.com/verus-lang/verus/pull/1545) .