### PR TITLE
add cli interface of proof deghosting

### DIFF
--- a/code/lynette.py
+++ b/code/lynette.py
@@ -5,6 +5,7 @@
 import os
 import subprocess
 
+from typing import Literal
 
 class Lynette:
     meta_command = [
@@ -47,5 +48,13 @@ class Lynette:
     def code_detect_nonlinear(self, file):
         return self.run(["code", "detect-nl", file])
 
+    def code_deghost(self, file, output_file, deghost_mode: str = Literal["raw", "unverified"], run_fmt: bool = True):
+        LYNETTE_PATH = os.environ.get("LYNETTE_PATH")
+        if not LYNETTE_PATH:
+            raise EnvironmentError("LYNETTE_PATH environment variable is not set.")
+        command = [LYNETTE_PATH, "code", "deghost", file, "--mode", deghost_mode, "-o", output_file]
+        subprocess.run(command)
+        if run_fmt:
+            subprocess.run(['verusfmt', output_file])
 
 lynette = Lynette()

--- a/code/lynette.py
+++ b/code/lynette.py
@@ -48,7 +48,7 @@ class Lynette:
     def code_detect_nonlinear(self, file):
         return self.run(["code", "detect-nl", file])
 
-    def code_deghost(self, file, output_file, deghost_mode: str = Literal["raw", "unverified"], run_fmt: bool = True):
+    def code_deghost(self, file, output_file, deghost_mode: Literal["raw", "unverified"] = "raw", run_fmt: bool = True):
         LYNETTE_PATH = os.environ.get("LYNETTE_PATH")
         if not LYNETTE_PATH:
             raise EnvironmentError("LYNETTE_PATH environment variable is not set.")

--- a/code/utils_inter.py
+++ b/code/utils_inter.py
@@ -39,6 +39,17 @@ def split_code_by_func(code, oprefix, tofile=False):
             name = re.sub(r'.+fn ','',tmp)
             names.append(name)
 
+            # check if the function is empty
+            if line.strip().endswith("{}"):
+                intervalend.append(i)
+                if tofile == True:
+                    output_file = oprefix + "_{}_".format(findex) + name + "_.rs"                
+                    ofiles.append(output_file)
+                    with open(output_file, "w") as wf:
+                        wf.write(fcode)
+                findex += 1
+                continue
+
             #get function ending line number
             ident = len(line) - len(line.lstrip())
             j = i + 1

--- a/code/veval.py
+++ b/code/veval.py
@@ -85,7 +85,8 @@ class Verus:
 
 
 verus = Verus()
-
+import shutil
+verus.set_verus_path(shutil.which("verus"))
 
 class ErrorText:
     def __init__(self, text):

--- a/code/veval.py
+++ b/code/veval.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import json
 from enum import Enum
+import shutil
 
 
 class VerusErrorType(Enum):
@@ -85,7 +86,6 @@ class Verus:
 
 
 verus = Verus()
-import shutil
 verus.set_verus_path(shutil.which("verus"))
 
 class ErrorText:

--- a/utils/lynette/source/lynette/src/deghost.rs
+++ b/utils/lynette/source/lynette/src/deghost.rs
@@ -261,11 +261,14 @@ fn remove_ghost_sig(
         paren_token: sig.paren_token.clone(),
         inputs: sig.inputs.clone(),
         variadic: sig.variadic.clone(),
-        output: match &sig.output {
-            syn_verus::ReturnType::Type(_, _, _, ty) => {
-                syn_verus::ReturnType::Type(Default::default(), None, None, ty.clone())
+        output: match mode.sig_output {
+            true => sig.output.clone(),
+            false => match &sig.output {
+                syn_verus::ReturnType::Type(_, _, _, ty) => {
+                    syn_verus::ReturnType::Type(Default::default(), None, None, ty.clone())
+                }
+                syn_verus::ReturnType::Default => syn_verus::ReturnType::Default,
             }
-            syn_verus::ReturnType::Default => syn_verus::ReturnType::Default,
         },
         prover: sig.prover.clone(), // Removed
         // TODO: This fix needs to be propagated to other places using `Specification`

--- a/utils/lynette/source/lynette/src/main.rs
+++ b/utils/lynette/source/lynette/src/main.rs
@@ -764,7 +764,7 @@ fn main() {
                             requires: true,    // Keep all preconditions  
                             ensures: true,     // Keep all postconditions  
                             invariants: false,
-                            spec: false,
+                            spec: true,     // Keep all spec functions
                             asserts: false,
                             asserts_anno: false,
                             decreases: false,

--- a/utils/lynette/source/lynette/src/main.rs
+++ b/utils/lynette/source/lynette/src/main.rs
@@ -822,15 +822,11 @@ fn main() {
                                 // Format output based on mode
                                 let final_output = match mode_str {
                                     "raw" => {
-                                        // // Remove vstd import and verus macro wrapper
-                                        // let filtered_non_verus = non_verus_content
-                                        //     .lines()
-                                        //     .filter(|line| !line.trim().starts_with("use vstd::prelude::*;"))
-                                        //     .collect::<Vec<_>>()
-                                        //     .join("\n");
+                                        // comment out the `use vstd::prelude::*;` import
+                                        let non_verus_content_no_import = non_verus_content.replace("use vstd::prelude::*;", "// use vstd::prelude::*;");
 
                                         // Just output the deghosted content without verus wrapper
-                                        format!("{}\n{}", non_verus_content.trim(), deghosted_output)
+                                        format!("{}\n{}", non_verus_content_no_import.trim(), deghosted_output)
                                     },
                                     "unverified" => {
                                         // Keep the verus macro wrapper and imports


### PR DESCRIPTION
The code base already has functionality of deghosting. I tried to implement a CLI interface for more convenient deghosting a proof. The input is a verified proof, and the output is either a raw program that can be directly compiled or an "unverified proof" where invariants, asserts, proof functions, etc. are removed (so that it can serve as an input for AutoVerus).