### PR TITLE
Update README.md with correct path to get_z3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python verify.py --name gpt4o-ab-sampled --config-file config-artifact-openai.js
    git clone https://github.com/verus-lang/verus.git
    cd verus
    git checkout 33269ac6a0ea33a08109eefe5016c1fdd0ce9fbd
-   ./tools/get-z3.sh && source tools/activate
+   ./source/tools/get-z3.sh && source tools/activate
    vargo build --release
    ```
 


### PR DESCRIPTION
It is at https://github.com/verus-lang/verus/blob/33269ac6a0ea33a08109eefe5016c1fdd0ce9fbd/source/tools/get-z3.sh, additional ./source directory needs to be added