### PR TITLE
Fix logical condition in findmax.rs

### DIFF
--- a/benchmarks/Verus-Bench/Misc/verified/findmax.rs
+++ b/benchmarks/Verus-Bench/Misc/verified/findmax.rs
@@ -8,7 +8,7 @@ requires
     nums.len() > 0,
 ensures
     forall |i: int| 0 <= i < nums@.len() ==> nums@[i] <= ret,
-    exists |i: int| 0 <= i < nums@.len() ==> nums@[i] == ret,
+    exists |i: int| 0 <= i < nums@.len() && nums@[i] == ret,
 {
     let mut max = nums[0];
     let mut i = 1;


### PR DESCRIPTION
The original postcondition "exists |i: int| 0 <= i < nums@.len() ==> nums@[i] == ret" is trivially true, could @arsene1995 please take a look? thanks