### PR TITLE
Fix leaderboard deploy not triggering on large pushes

### DIFF
--- a/.github/workflows/deploy-leaderboard.yml
+++ b/.github/workflows/deploy-leaderboard.yml
@@ -2,11 +2,12 @@
 name: Deploy Leaderboard to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on every push to the default branch. Deliberately no `paths:` filter:
+  # GitHub only inspects the first 300 changed files of a push when evaluating
+  # path filters, so a large push (e.g. adding hundreds of benchmark tasks
+  # alongside a leaderboard change) can silently skip the deploy.
   push:
     branches: ["main", "leaderboard"]
-    paths:
-      - 'leaderboard/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Problem

The leaderboard at https://microsoft.github.io/verus-proof-synthesis/ was not updated after PR #48 merged, even though that PR changed `leaderboard/**` files and the deploy workflow triggers on `paths: ['leaderboard/**']`.

Root cause: [GitHub only evaluates push path filters against the first 300 changed files](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#git-diff-comparisons). The PR #48 merge changed 468 files — 463 under `benchmarks/` and 5 under `leaderboard/`. The alphabetically-first 300 were all `benchmarks/` files, so the filter never matched and the deploy was silently skipped (last successful deploy run: Jan 22, PR #42).

## Fix

Drop the `paths:` filter and deploy on every push to `main`. The deploy is a cheap static upload (~30s), and this repo routinely lands leaderboard changes alongside hundreds of benchmark files, so the same silent skip would keep recurring.

Merging this PR will itself trigger a deploy that picks up the no-lemma leaderboard track already on `main`.